### PR TITLE
Add remote invocation

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -31,3 +31,4 @@ ignorePatterns:
   - jest.config.js
   - "dist/"
   - "examples/"
+  - "coverage/"

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -13,7 +13,7 @@ permissions:
   id-token: write
 
 jobs:
-  ci:
+  cicd:
     runs-on: ubuntu-latest
 
     steps:
@@ -30,6 +30,10 @@ jobs:
         run: npm run lint
       - name: Run tests
         run: npm test
+      - name: Upload coverage report to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Build
         run: npm run build
       - name: Publish

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 node_modules/
 out/
 dist/
+coverage/
 .next/
 mydb.sqlite

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
+  collectCoverage: true,
+  coverageDirectory: "coverage",
   preset: "ts-jest",
   testEnvironment: "node",
   testPathIgnorePatterns: ["dist/", "lib/core/loggers/test.ts"],

--- a/lib/core/bucket.ts
+++ b/lib/core/bucket.ts
@@ -1,3 +1,3 @@
 export interface IBucket {
-  schedule<R>(thunk: () => R, delay: number): Promise<R>;
+  schedule<R>(thunk: () => R, delay?: number): Promise<R>;
 }

--- a/lib/core/error.ts
+++ b/lib/core/error.ts
@@ -5,13 +5,14 @@ export enum ErrorCodes {
   FORBIDDEN = 3,
   NOT_FOUND = 4,
   ALREADY_EXISTS = 5,
-  ENCODER = 6,
+  INVALID_STATE = 6,
+  ENCODER = 7,
 }
 
 export class ResonateError extends Error {
   constructor(
-    public readonly message: string,
     public readonly code: ErrorCodes,
+    public readonly message: string,
     public readonly cause?: any,
     public readonly retryable: boolean = false,
   ) {
@@ -19,6 +20,6 @@ export class ResonateError extends Error {
   }
 
   public static fromError(e: unknown): ResonateError {
-    return e instanceof ResonateError ? e : new ResonateError("Unexpected error", ErrorCodes.UNKNOWN, e);
+    return e instanceof ResonateError ? e : new ResonateError(ErrorCodes.UNKNOWN, "Unexpected error", e);
   }
 }

--- a/lib/core/logger.ts
+++ b/lib/core/logger.ts
@@ -1,4 +1,8 @@
 export interface ILogger {
+  debug(...args: any[]): void;
+  info(...args: any[]): void;
+  warn(...args: any[]): void;
+  error(...args: any[]): void;
   startTrace(id: string, attrs?: Record<string, string>): ITrace;
 }
 

--- a/lib/core/loggers/opentelemetry.ts
+++ b/lib/core/loggers/opentelemetry.ts
@@ -1,7 +1,8 @@
 import * as opentelemetry from "@opentelemetry/api";
+import { Logger } from "./logger";
 import { ILogger, ITrace } from "../logger";
 
-export class OpenTelemetryLogger implements ILogger {
+export class OpenTelemetryLogger extends Logger implements ILogger {
   startTrace(id: string, attrs?: Record<string, string>): ITrace {
     return new OpenTelemetrySpan(id, attrs);
   }

--- a/lib/core/loggers/test.ts
+++ b/lib/core/loggers/test.ts
@@ -1,6 +1,7 @@
+import { Logger } from "./logger";
 import { ILogger, ITrace } from "../logger";
 
-export class TestLogger implements ILogger {
+export class TestLogger extends Logger implements ILogger {
   public traces: any[] = [];
 
   startTrace(id: string, attrs?: Record<string, string>): ITrace {

--- a/lib/core/retries/exponential.ts
+++ b/lib/core/retries/exponential.ts
@@ -1,7 +1,7 @@
 import { Context } from "../../resonate";
 import { IRetry } from "../retry";
 
-export class Retry implements IRetry {
+export class ExponentialRetry implements IRetry {
   constructor(
     private maxAttempts: number,
     private maxDelay: number,
@@ -9,8 +9,8 @@ export class Retry implements IRetry {
     private backoffFactor: number,
   ) {}
 
-  static atMostOnce(): Retry {
-    return new Retry(1, 0, 0, 0);
+  static atMostOnce(): ExponentialRetry {
+    return new ExponentialRetry(1, 0, 0, 0);
   }
 
   static atLeastOnce(
@@ -18,8 +18,8 @@ export class Retry implements IRetry {
     maxDelay: number = 60000, // 1 minute
     initialDelay: number = 100,
     backoffFactor: number = 2,
-  ): Retry {
-    return new Retry(maxAttempts, maxDelay, initialDelay, backoffFactor);
+  ): ExponentialRetry {
+    return new ExponentialRetry(maxAttempts, maxDelay, initialDelay, backoffFactor);
   }
 
   next(context: Context): { done: boolean; delay?: number } {

--- a/lib/core/retries/linear.ts
+++ b/lib/core/retries/linear.ts
@@ -1,0 +1,20 @@
+import { Context } from "../../resonate";
+import { IRetry } from "../retry";
+
+export class LinearRetry implements IRetry {
+  constructor(
+    private delay: number,
+    private maxAttempts: number = Infinity,
+  ) {}
+
+  next(context: Context): { done: boolean; delay?: number } {
+    if (Date.now() >= context.timeout || context.attempt >= this.maxAttempts) {
+      return { done: true };
+    }
+
+    return {
+      done: false,
+      delay: this.delay,
+    };
+  }
+}

--- a/lib/core/stores/local.ts
+++ b/lib/core/stores/local.ts
@@ -11,8 +11,6 @@ import {
   isCanceledPromise,
 } from "../promise";
 import { IPromiseStore } from "../store";
-import { IEncoder } from "../encoder";
-import { Base64Encoder } from "../encoders/base64";
 import { ErrorCodes, ResonateError } from "../error";
 import { IStorage, WithTimeout } from "../storage";
 import { MemoryStorage } from "../storages/memory";
@@ -20,10 +18,7 @@ import { MemoryStorage } from "../storages/memory";
 export class LocalPromiseStore implements IPromiseStore {
   private storage: IStorage;
 
-  constructor(
-    storage: IStorage = new MemoryStorage(),
-    private encoder: IEncoder<string, string> = new Base64Encoder(),
-  ) {
+  constructor(storage: IStorage = new MemoryStorage()) {
     this.storage = new WithTimeout(storage);
   }
 
@@ -39,11 +34,11 @@ export class LocalPromiseStore implements IPromiseStore {
     return this.storage.rmw(id, (promise) => {
       if (promise) {
         if (strict && !isPendingPromise(promise)) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         if (promise.idempotencyKeyForCreate === undefined || ikey != promise.idempotencyKeyForCreate) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         return promise;
@@ -80,7 +75,7 @@ export class LocalPromiseStore implements IPromiseStore {
     return this.storage.rmw(id, (promise) => {
       if (promise) {
         if (strict && !isPendingPromise(promise) && !isResolvedPromise(promise)) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         if (isPendingPromise(promise)) {
@@ -102,12 +97,12 @@ export class LocalPromiseStore implements IPromiseStore {
         }
 
         if (promise.idempotencyKeyForComplete === undefined || ikey != promise.idempotencyKeyForComplete) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         return promise;
       } else {
-        throw new ResonateError("Not found", ErrorCodes.NOT_FOUND);
+        throw new ResonateError(ErrorCodes.NOT_FOUND, "Not found");
       }
     });
   }
@@ -122,7 +117,7 @@ export class LocalPromiseStore implements IPromiseStore {
     return this.storage.rmw(id, (promise) => {
       if (promise) {
         if (strict && !isPendingPromise(promise) && !isRejectedPromise(promise)) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         if (isPendingPromise(promise)) {
@@ -144,12 +139,12 @@ export class LocalPromiseStore implements IPromiseStore {
         }
 
         if (promise.idempotencyKeyForComplete === undefined || ikey != promise.idempotencyKeyForComplete) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         return promise;
       } else {
-        throw new ResonateError("Not found", ErrorCodes.NOT_FOUND);
+        throw new ResonateError(ErrorCodes.NOT_FOUND, "Not found");
       }
     });
   }
@@ -164,7 +159,7 @@ export class LocalPromiseStore implements IPromiseStore {
     return this.storage.rmw(id, (promise) => {
       if (promise) {
         if (strict && !isPendingPromise(promise) && !isCanceledPromise(promise)) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         if (isPendingPromise(promise)) {
@@ -186,12 +181,12 @@ export class LocalPromiseStore implements IPromiseStore {
         }
 
         if (promise.idempotencyKeyForComplete === undefined || ikey != promise.idempotencyKeyForComplete) {
-          throw new ResonateError("Forbidden request", ErrorCodes.FORBIDDEN);
+          throw new ResonateError(ErrorCodes.FORBIDDEN, "Forbidden request");
         }
 
         return promise;
       } else {
-        throw new ResonateError("Not found", ErrorCodes.NOT_FOUND);
+        throw new ResonateError(ErrorCodes.NOT_FOUND, "Not found");
       }
     });
   }
@@ -203,6 +198,6 @@ export class LocalPromiseStore implements IPromiseStore {
       return promise;
     }
 
-    throw new ResonateError("Not found", ErrorCodes.NOT_FOUND);
+    throw new ResonateError(ErrorCodes.NOT_FOUND, "Not found");
   }
 }

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -60,9 +60,9 @@ export class Resonate {
 
   readonly defaultRetry: () => IRetry;
 
-  readonly valueEncoder: DataEncoder;
-
   readonly paramEncoder: DataEncoder;
+
+  readonly valueEncoder: DataEncoder;
 
   readonly errorEncoder: DataEncoder;
 
@@ -87,8 +87,8 @@ export class Resonate {
     this.logger = logger;
     this.defaultRetry = retry;
 
-    this.valueEncoder = new DataEncoder(encoder);
     this.paramEncoder = new DataEncoder(encoder);
+    this.valueEncoder = new DataEncoder(encoder);
     this.errorEncoder = new DataEncoder(encoder, new ErrorEncoder());
 
     this.addStore("default", url ? new RemotePromiseStore(url) : new LocalPromiseStore());
@@ -484,8 +484,6 @@ class LInvocation<A extends any[], R> {
       } catch (e: unknown) {
         context.kill(ResonateError.fromError(e));
         return;
-      } finally {
-        trace.end();
       }
     });
   }

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -21,7 +21,7 @@ type F<A extends any[], R> = (c: Context, ...a: A) => R;
 type G<A extends any[], R> = (c: Context, ...a: A) => Generator<Promise<any>, R, any>;
 
 type DurableFunction<A extends any[], R> = G<A, R> | F<A, R>;
-type Invocation<A extends any[], R> = AInvocation<A, R> | GInvocation<A, R>;
+type Invocation<A extends any[], R> = LInvocation<A, R> | RInvocation<A, R> | AInvocation<A, R> | GInvocation<A, R>;
 
 type WithOpts<A extends any[]> = [...A, Partial<Opts>?];
 
@@ -62,6 +62,8 @@ export class Resonate {
 
   readonly valueEncoder: DataEncoder;
 
+  readonly paramEncoder: DataEncoder;
+
   readonly errorEncoder: DataEncoder;
 
   /**
@@ -86,6 +88,7 @@ export class Resonate {
     this.defaultRetry = retry;
 
     this.valueEncoder = new DataEncoder(encoder);
+    this.paramEncoder = new DataEncoder(encoder);
     this.errorEncoder = new DataEncoder(encoder, new ErrorEncoder());
 
     this.addStore("default", url ? new RemotePromiseStore(url) : new LocalPromiseStore());
@@ -288,7 +291,7 @@ export interface Context {
    * @param args arguments to pass to the function, optionally followed by Resonate {@link Opts}
    * @returns a promise that resolves to the return value of the function
    */
-  run<A extends any[], R>(func: DurableFunction<A, R>, ...args: WithOpts<A>): Promise<R>;
+  run<A extends any[], R>(func: DurableFunction<A, R> | string, ...args: WithOpts<A>): Promise<R>;
 }
 
 class ResonateContext implements Context {
@@ -332,7 +335,7 @@ class ResonateContext implements Context {
     this.children.push(context);
   }
 
-  run<A extends any[], R>(func: DurableFunction<A, R>, ...argsWithOpts: WithOpts<A>): Promise<R> {
+  run<A extends any[], R>(func: DurableFunction<A, R> | string, ...argsWithOpts: WithOpts<A>): Promise<R> {
     const id = `${this.opts.id}.${this.counter++}`;
     const [args, opts] = splitArgs(argsWithOpts);
 
@@ -352,7 +355,7 @@ class ResonateContext implements Context {
     return context.execute(func, args);
   }
 
-  execute<A extends any[], R>(func: DurableFunction<A, R>, args: A): Promise<R> {
+  execute<A extends any[], R>(func: DurableFunction<A, R> | string, args: A): Promise<R> {
     return new Promise(async (resolve, reject) => {
       // set reject for kill/cancel
       this.reject = reject;
@@ -360,90 +363,31 @@ class ResonateContext implements Context {
       const store = this.resonate.store(this.opts.store);
       const bucket = this.resonate.bucket(this.opts.bucket);
 
-      const trace = this.parent?.trace ? this.parent.trace.start(this.id) : this.resonate.logger.startTrace(this.id);
-
       let invocation: Invocation<A, R>;
-      if (isF<A, R>(func)) {
-        invocation = new AInvocation(func, args, this.opts.retry, trace);
+      if (typeof func === "string") {
+        invocation = new RInvocation(func, args, store);
+      } else if (isF<A, R>(func)) {
+        invocation = new LInvocation(store, new AInvocation(func, args, bucket, this.opts.retry));
       } else if (isG<A, R>(func)) {
-        invocation = new GInvocation(func, args, this.opts.retry, trace);
+        invocation = new LInvocation(store, new GInvocation(func, args, bucket, this.opts.retry));
       } else {
-        trace.end();
         throw new Error("Invalid function");
       }
 
-      // create durable promise
+      const trace = this.parent?.trace ? this.parent.trace.start(this.id) : this.resonate.logger.startTrace(this.id);
+
+      // linvocation / rinovcation
       try {
-        const p = await store.create(
-          this.id,
-          this.idempotencyKey,
-          false,
-          undefined,
-          undefined,
-          this.timeout,
-          undefined,
-        );
-
-        if (isPendingPromise(p)) {
-          try {
-            // invoke function
-            const r = await invocation.invoke(this, bucket);
-
-            try {
-              // encode value
-              const { headers, data } = this.encode(r, this.resonate.valueEncoder);
-
-              // resolve durable promise
-              const p = await store.resolve(this.id, this.idempotencyKey, false, headers, data);
-
-              if (isResolvedPromise(p)) {
-                resolve(this.decode(p.value, this.resonate.valueEncoder));
-                return;
-              } else {
-                reject(this.decode(p.value, this.resonate.errorEncoder));
-                return;
-              }
-            } catch (e: unknown) {
-              this.kill(ResonateError.fromError(e));
-              return;
-            }
-          } catch (e: unknown) {
-            try {
-              // encode error
-              const { headers, data } = this.encode(e, this.resonate.errorEncoder);
-
-              // reject durable promise
-              const p = await store.reject(this.id, this.idempotencyKey, false, headers, data);
-
-              if (isResolvedPromise(p)) {
-                resolve(this.decode(p.value, this.resonate.valueEncoder));
-                return;
-              } else {
-                reject(this.decode(p.value, this.resonate.errorEncoder));
-                return;
-              }
-            } catch (e: unknown) {
-              this.kill(ResonateError.fromError(e));
-              return;
-            }
-          }
-        } else if (isResolvedPromise(p)) {
-          resolve(this.decode(p.value, this.resonate.valueEncoder));
-          return;
-        } else {
-          reject(this.decode(p.value, this.resonate.errorEncoder));
-          return;
-        }
+        resolve(await invocation.invoke(this, trace));
       } catch (e: unknown) {
-        this.kill(ResonateError.fromError(e));
-        return;
-      } finally {
-        trace.end();
+        reject(e);
       }
+
+      trace.end();
     });
   }
 
-  private kill(e: ResonateError) {
+  kill(e: ResonateError) {
     this.killed = true;
 
     if (this.parent) {
@@ -454,7 +398,7 @@ class ResonateContext implements Context {
     }
   }
 
-  private cancel() {
+  cancel() {
     for (const child of this.children) {
       child.cancel();
     }
@@ -463,43 +407,142 @@ class ResonateContext implements Context {
 
     this.canceled = true;
   }
-
-  // wrap encoder error in ResonateError
-  private encode<T>(
-    value: T,
-    encoder: DataEncoder,
-  ): { headers: Record<string, string> | undefined; data: string | undefined } {
-    try {
-      return encoder.encode(value);
-    } catch (e: unknown) {
-      throw new ResonateError("Encode error", ErrorCodes.ENCODER, e);
-    }
-  }
-
-  // wrap decoder error in ResonateError
-  private decode<T>(
-    value: { headers: Record<string, string> | undefined; data: string | undefined },
-    encoder: DataEncoder,
-  ): T {
-    try {
-      return encoder.decode(value);
-    } catch (e: unknown) {
-      throw new ResonateError("Decode error", ErrorCodes.ENCODER, e);
-    }
-  }
 }
 
 // Invocations
+
+class LInvocation<A extends any[], R> {
+  constructor(
+    private store: IPromiseStore,
+    private invocation: Invocation<A, R>,
+  ) {}
+
+  async invoke(context: ResonateContext, trace: ITrace): Promise<R> {
+    return new Promise(async (resolve, reject) => {
+      // create durable promise
+      try {
+        const p = await this.store.create(
+          context.id,
+          context.idempotencyKey,
+          false,
+          undefined,
+          undefined,
+          context.timeout,
+          undefined,
+        );
+
+        if (isPendingPromise(p)) {
+          try {
+            // invoke function
+            const r = await this.invocation.invoke(context, trace);
+
+            try {
+              // encode value
+              const { headers, data } = encode(r, context.resonate.valueEncoder);
+
+              // resolve durable promise
+              const p = await this.store.resolve(context.id, context.idempotencyKey, false, headers, data);
+
+              if (isResolvedPromise(p)) {
+                resolve(decode(p.value, context.resonate.valueEncoder));
+                return;
+              } else {
+                reject(decode(p.value, context.resonate.errorEncoder));
+                return;
+              }
+            } catch (e: unknown) {
+              context.kill(ResonateError.fromError(e));
+              return;
+            }
+          } catch (e: unknown) {
+            try {
+              // encode error
+              const { headers, data } = encode(e, context.resonate.errorEncoder);
+
+              // reject durable promise
+              const p = await this.store.reject(context.id, context.idempotencyKey, false, headers, data);
+
+              if (isResolvedPromise(p)) {
+                resolve(decode(p.value, context.resonate.valueEncoder));
+                return;
+              } else {
+                reject(decode(p.value, context.resonate.errorEncoder));
+                return;
+              }
+            } catch (e: unknown) {
+              context.kill(ResonateError.fromError(e));
+              return;
+            }
+          }
+        } else if (isResolvedPromise(p)) {
+          resolve(decode(p.value, context.resonate.valueEncoder));
+          return;
+        } else {
+          reject(decode(p.value, context.resonate.errorEncoder));
+          return;
+        }
+      } catch (e: unknown) {
+        context.kill(ResonateError.fromError(e));
+        return;
+      } finally {
+        trace.end();
+      }
+    });
+  }
+}
+
+class RInvocation<A extends any[], R> {
+  constructor(
+    private id: string,
+    private args: A,
+    private store: IPromiseStore,
+  ) {}
+
+  async invoke(context: ResonateContext, trace: ITrace): Promise<R> {
+    return new Promise(async (resolve, reject) => {
+      // create durable promise
+      try {
+        const { headers, data } = encode(this.args, context.resonate.errorEncoder);
+
+        let p = await this.store.create(
+          this.id,
+          context.idempotencyKey,
+          false,
+          headers,
+          data,
+          context.timeout,
+          undefined,
+        );
+
+        while (isPendingPromise(p)) {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          p = await this.store.get(this.id);
+        }
+
+        if (isResolvedPromise(p)) {
+          resolve(decode(p.value, context.resonate.valueEncoder));
+          return;
+        } else {
+          reject(decode(p.value, context.resonate.errorEncoder));
+          return;
+        }
+      } catch (e: unknown) {
+        context.kill(ResonateError.fromError(e));
+        return;
+      }
+    });
+  }
+}
 
 class AInvocation<A extends any[], R> {
   constructor(
     private func: F<A, R>,
     private args: A,
+    private bucket: IBucket,
     private retry: IRetry,
-    private trace: ITrace,
   ) {}
 
-  invoke(context: ResonateContext, bucket: Bucket): Promise<R> {
+  invoke(context: ResonateContext, trace: ITrace): Promise<R> {
     return new Promise(async (resolve, reject) => {
       let r = this.retry.next(context);
 
@@ -507,12 +550,12 @@ class AInvocation<A extends any[], R> {
         const thunk = () => {
           // set the current trace on the context
           // this will be used to create child traces
-          context.trace = this.trace.start(`${context.id}:${context.attempt}`);
+          context.trace = trace.start(`${context.id}:${context.attempt}`);
           return this.func(context, ...this.args);
         };
 
         try {
-          resolve(await bucket.schedule(thunk, r.delay));
+          resolve(await this.bucket.schedule(thunk, r.delay));
           return;
         } catch (e: unknown) {
           context.attempt++;
@@ -534,11 +577,11 @@ class GInvocation<A extends any[], R> {
   constructor(
     private func: G<A, R>,
     private args: A,
+    private bucket: IBucket,
     private retry: IRetry,
-    private trace: ITrace,
   ) {}
 
-  invoke(context: ResonateContext, bucket: Bucket): Promise<R> {
+  invoke(context: ResonateContext, trace: ITrace): Promise<R> {
     return new Promise(async (resolve, reject) => {
       let r = this.retry.next(context);
 
@@ -551,12 +594,12 @@ class GInvocation<A extends any[], R> {
           const thunk = () => {
             // set the current trace on the context
             // this will be used to create child traces
-            context.trace = this.trace.start(`${context.id}:${context.attempt}`);
+            context.trace = trace.start(`${context.id}:${context.attempt}`);
 
             return generator.next();
           };
 
-          let g = await bucket.schedule(thunk, r.delay);
+          let g = await this.bucket.schedule(thunk, r.delay);
 
           while (!g.done) {
             try {
@@ -572,7 +615,7 @@ class GInvocation<A extends any[], R> {
               next = () => generator.next(lastValue);
             }
 
-            g = await bucket.schedule(next);
+            g = await this.bucket.schedule(next);
           }
 
           resolve(await g.value);
@@ -594,6 +637,30 @@ class GInvocation<A extends any[], R> {
 }
 
 // Utils
+
+// wrap encoder error in ResonateError
+function encode<T>(
+  value: T,
+  encoder: DataEncoder,
+): { headers: Record<string, string> | undefined; data: string | undefined } {
+  try {
+    return encoder.encode(value);
+  } catch (e: unknown) {
+    throw new ResonateError("Encode error", ErrorCodes.ENCODER, e);
+  }
+}
+
+// wrap decoder error in ResonateError
+function decode<T>(
+  value: { headers: Record<string, string> | undefined; data: string | undefined },
+  encoder: DataEncoder,
+): T {
+  try {
+    return encoder.decode(value);
+  } catch (e: unknown) {
+    throw new ResonateError("Decode error", ErrorCodes.ENCODER, e);
+  }
+}
 
 function splitArgs<A extends any[]>(argsWithOpts: WithOpts<A>): [A, Partial<Opts>] {
   let args: A;

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -1,5 +1,6 @@
 import { jest, describe, test, expect } from "@jest/globals";
 
+import { Logger } from "../lib/core/loggers/logger";
 import { RemotePromiseStore } from "../lib/core/stores/remote";
 import { LocalPromiseStore } from "../lib/core/stores/local";
 
@@ -9,7 +10,7 @@ jest.setTimeout(10000);
 describe("Resonate Server Tests", () => {
   const useDurable = process.env.USE_DURABLE === "true";
   const url = process.env.RESONATE_URL || "http://localhost:8001";
-  const store = useDurable ? new RemotePromiseStore(url) : new LocalPromiseStore();
+  const store = useDurable ? new RemotePromiseStore(url, new Logger()) : new LocalPromiseStore();
 
   describe("State Transition Tests", () => {
     test("Test Case 0: transitions from Init to Pending via Create", async () => {


### PR DESCRIPTION
```ts
run<A extends any[], R>(func: DurableFunction<A, R> | string, ...args: WithOpts<A>): Promise<R>;
```

Extends `context.run()` to optionally accept a string, if a string is provided Resonate will start an instance of `RInvocation` which create and polls a promise until it is complete. The promise is expected to be resolved/reject out-of-process. 