### PR TITLE
Refactor Stores and Storages and implement local locking

### DIFF
--- a/lib/core/lock.ts
+++ b/lib/core/lock.ts
@@ -1,0 +1,5 @@
+export type Lock = {
+    id: string;
+    pid: string;
+    eid: string;
+}

--- a/lib/core/lock.ts
+++ b/lib/core/lock.ts
@@ -1,5 +1,5 @@
 export type Lock = {
-    id: string;
-    pid: string;
-    eid: string;
-}
+  id: string;
+  pid: string;
+  eid: string;
+};

--- a/lib/core/storage.ts
+++ b/lib/core/storage.ts
@@ -1,23 +1,5 @@
-import { DurablePromise } from "./promise";
-import { Schedule } from "./schedule";
-
-export interface IPromiseStorage {
-  rmw<P extends DurablePromise | undefined>(id: string, f: (promise: DurablePromise | undefined) => P): Promise<P>;
-  search(
-    id: string,
-    state: string | undefined,
-    tags: Record<string, string> | undefined,
-    limit: number | undefined,
-  ): AsyncGenerator<DurablePromise[], void>;
-}
-
-export interface IScheduleStorage {
-  rmw<S extends Schedule | undefined>(id: string, f: (schedule: Schedule | undefined) => S): Promise<S>;
-  search(
-    id: string,
-    tags: Record<string, string> | undefined,
-    limit: number | undefined,
-  ): AsyncGenerator<Schedule[], void>;
-
-  delete(id: string): Promise<boolean>;
+export interface IStorage<T> {
+  rmw<X extends T | undefined>(id: string, func: (item: T | undefined) => X): Promise<X>;
+  rmd(id: string, func: (item: T) => boolean): Promise<void>;
+  all(): AsyncGenerator<T[], void>;
 }

--- a/lib/core/storages/indexdb.ts
+++ b/lib/core/storages/indexdb.ts
@@ -51,10 +51,7 @@ export class IndexedDbStorage implements IStorage<DurablePromise> {
     return resultPromise;
   }
 
-  async rmd(
-    id: string,
-    f: (promise: DurablePromise) => boolean,
-  ): Promise<void> {
+  async rmd(id: string, f: (promise: DurablePromise) => boolean): Promise<void> {
     // unimplemented
   }
 

--- a/lib/core/storages/indexdb.ts
+++ b/lib/core/storages/indexdb.ts
@@ -1,9 +1,9 @@
-import { IPromiseStorage } from "../storage";
+import { IStorage } from "../storage";
 import { DurablePromise, isDurablePromise } from "../promise";
 import { ResonateError, ErrorCodes } from "../error";
 import { Schedule } from "../schedule";
 
-export class IndexedDbStorage implements IPromiseStorage {
+export class IndexedDbStorage implements IStorage<DurablePromise> {
   private dbName = "resonateDB";
   private readonly storeName = "promises";
   private db: Promise<IDBDatabase>;
@@ -51,24 +51,19 @@ export class IndexedDbStorage implements IPromiseStorage {
     return resultPromise;
   }
 
-  async *search(
+  async rmd(
     id: string,
-    state: string | undefined,
-    tags: Record<string, string> | undefined,
-    limit: number | undefined,
-  ): AsyncGenerator<DurablePromise[], void> {
-    // for now WithTimeout will implement
-    // search logic
+    f: (promise: DurablePromise) => boolean,
+  ): Promise<void> {
+    // unimplemented
+  }
+
+  async *all(): AsyncGenerator<DurablePromise[], void> {
     const db = await this.getDb();
     const transaction = db.transaction(this.storeName, "readwrite");
     const objectStore = transaction.objectStore(this.storeName);
 
     yield this.getAllPromises(objectStore);
-  }
-
-  async deleteSchedule(id: string): Promise<boolean> {
-    // TODO: To be implemented
-    return true;
   }
 
   private async getDb(): Promise<IDBDatabase> {

--- a/lib/core/storages/memory.ts
+++ b/lib/core/storages/memory.ts
@@ -1,99 +1,26 @@
-import { IPromiseStorage, IScheduleStorage } from "../storage";
-import { ILockStore } from "../store";
-import { DurablePromise, searchStates } from "../promise";
-import { Schedule } from "../schedule";
+import { IStorage } from "../storage";
 
-export class MemoryPromiseStorage implements IPromiseStorage {
-  private promises: Record<string, DurablePromise> = {};
-  constructor() {}
+export class MemoryStorage<T> implements IStorage<T> {
+  private items: Record<string, T> = {};
 
-  async rmw<P extends DurablePromise | undefined>(id: string, f: (item: DurablePromise | undefined) => P): Promise<P> {
-    const item = f(this.promises[id]);
+  async rmw<X extends T | undefined>(id: string, func: (item: T | undefined) => X): Promise<X> {
+    const item = func(this.items[id]);
     if (item) {
-      this.promises[id] = item;
+      this.items[id] = item;
     }
 
     return item;
   }
 
-  async *search(
-    id: string,
-    state: string | undefined,
-    tags: Record<string, string> | undefined,
-    limit: number | undefined,
-  ): AsyncGenerator<DurablePromise[], void> {
-    // for the memory storage, we will ignore limit and return all
-    // promises that match the search criteria
-    const regex = new RegExp(id.replaceAll("*", ".*"));
-    const states = searchStates(state);
-    const tagEntries = Object.entries(tags ?? {});
+  async rmd(id: string, func: (item: T) => boolean): Promise<void> {
+    const item = this.items[id];
 
-    yield Object.values(this.promises)
-      .filter((promise) => states.includes(promise.state))
-      .filter((promise) => regex.test(promise.id))
-      .filter((promise) => tagEntries.every(([k, v]) => promise.tags?.[k] == v));
-  }
-}
-
-export class MemoryScheduleStorage implements IScheduleStorage {
-  private schedules: Record<string, Schedule> = {};
-
-  constructor() {}
-
-  async rmw<S extends Schedule | undefined>(id: string, f: (item: Schedule | undefined) => S): Promise<S> {
-    const item = f(this.schedules[id]);
-    if (item) {
-      this.schedules[id] = item;
-    }
-
-    return item;
-  }
-
-  async *search(
-    id: string,
-    tags: Record<string, string> | undefined,
-    limit: number | undefined,
-  ): AsyncGenerator<Schedule[], void> {
-    // for the memory storage, we will ignore limit and return all
-    // schedules that match the search criteria
-    const regex = new RegExp(id.replaceAll("*", ".*"));
-    const tagEntries = Object.entries(tags ?? {});
-
-    yield Object.values(this.schedules)
-      .filter((schedule) => regex.test(schedule.id))
-      .filter((schedule) => tagEntries.every(([k, v]) => schedule.tags?.[k] == v));
-  }
-
-  async delete(id: string): Promise<boolean> {
-    if (this.schedules[id]) {
-      delete this.schedules[id];
-      return true;
-    }
-    return false;
-  }
-}
-
-export class MemoryLockStore implements ILockStore {
-  private locks: Record<string, { pid: string; eid: string }> = {};
-
-  tryAcquire(id: string, pid: string, eid: string): boolean {
-    if (!this.locks[id] || (this.locks[id] && this.locks[id].eid === eid)) {
-      // Lock is available, acquire it
-      this.locks[id] = { pid, eid };
-      return true;
-    } else {
-      // Lock is already acquired
-      return false;
+    if (item && func(item)) {
+      delete this.items[id];
     }
   }
 
-  release(id: string, eid: string): void {
-    if (this.locks[id] && this.locks[id].eid === eid) {
-      // Release the lock
-      delete this.locks[id];
-    } else {
-      // Lock was not acquired
-      throw new Error(`Lock with ID '${id}' not found.`);
-    }
+  async *all(): AsyncGenerator<T[], void> {
+    yield Object.values(this.items);
   }
 }

--- a/lib/core/store.ts
+++ b/lib/core/store.ts
@@ -166,7 +166,7 @@ export interface IScheduleStore {
    * @param id Unique identifier for the promise to be deleted.
    * @returns A promise schedule that is pending, canceled, resolved, or rejected.
    */
-  delete(id: string): Promise<boolean>;
+  delete(id: string): Promise<void>;
 
   /**
    * Search for schedules.
@@ -182,6 +182,6 @@ export interface IScheduleStore {
  * Lock Store API
  */
 export interface ILockStore {
-  tryAcquire(id: string, pid: string, eid: string): boolean;
-  release(id: string, eid: string): void;
+  tryAcquire(id: string, pid: string, eid: string): Promise<boolean>;
+  release(id: string, eid: string): Promise<void>;
 }

--- a/lib/core/stores/local.ts
+++ b/lib/core/stores/local.ts
@@ -421,19 +421,13 @@ export class LocalScheduleStore implements IScheduleStore {
     return schedule;
   }
 
-  async *search(
-    id: string,
-    tags?: Record<string, string>,
-    limit?: number,
-  ): AsyncGenerator<Schedule[], void> {
+  async *search(id: string, tags?: Record<string, string>, limit?: number): AsyncGenerator<Schedule[], void> {
     // filter the schedules returned from storage
     const regex = new RegExp(id.replaceAll("*", ".*"));
     const tagEntries = Object.entries(tags ?? {});
 
     for await (const schedules of this.storage.all()) {
-      yield schedules
-        .filter((s) => regex.test(s.id))
-        .filter((s) => tagEntries.every(([k, v]) => s.tags?.[k] == v));
+      yield schedules.filter((s) => regex.test(s.id)).filter((s) => tagEntries.every(([k, v]) => s.tags?.[k] == v));
     }
   }
 
@@ -446,9 +440,7 @@ export class LocalScheduleStore implements IScheduleStore {
 }
 
 export class LocalLockStore implements ILockStore {
-  constructor(
-    private storage: IStorage<Lock> = new MemoryStorage<Lock>(),
-  ) {}
+  constructor(private storage: IStorage<Lock> = new MemoryStorage<Lock>()) {}
 
   async tryAcquire(id: string, pid: string, eid: string): Promise<boolean> {
     const lock = await this.storage.rmw(id, (lock) => {

--- a/lib/core/stores/remote.ts
+++ b/lib/core/stores/remote.ts
@@ -8,7 +8,7 @@ import {
   isDurablePromise,
   isCompletedPromise,
 } from "../promise";
-import { IStore, IPromiseStore, IScheduleStore, ILockStore } from "../store";
+import { IStore, IPromiseStore, IScheduleStore } from "../store";
 import { IEncoder } from "../encoder";
 import { Base64Encoder } from "../encoders/base64";
 import { ErrorCodes, ResonateError } from "../error";

--- a/lib/core/stores/remote.ts
+++ b/lib/core/stores/remote.ts
@@ -15,19 +15,19 @@ import { ErrorCodes, ResonateError } from "../error";
 import { ILogger } from "../logger";
 import { Schedule, isSchedule } from "../schedule";
 import { Logger } from "../loggers/logger";
-import { MemoryLockStore } from "../storages/memory";
+import { LocalLockStore } from "./local";
 
 export class RemoteStore implements IStore {
   public promises: RemotePromiseStore;
   public schedules: RemoteScheduleStore;
-  public locks: ILockStore;
+  public locks: LocalLockStore;
 
   constructor(url: string, logger: ILogger, encoder: IEncoder<string, string> = new Base64Encoder()) {
     this.promises = new RemotePromiseStore(url, logger, encoder);
     this.schedules = new RemoteScheduleStore(url, logger, encoder);
 
     // temp
-    this.locks = new MemoryLockStore();
+    this.locks = new LocalLockStore();
   }
 }
 
@@ -325,7 +325,7 @@ export class RemoteScheduleStore implements IScheduleStore {
     return schedule;
   }
 
-  async delete(id: string): Promise<boolean> {
+  async delete(id: string): Promise<void> {
     await call(
       `${this.url}/schedules/${id}`,
       isDeleted,
@@ -338,7 +338,6 @@ export class RemoteScheduleStore implements IScheduleStore {
       },
       this.logger,
     );
-    return true;
   }
 
   async *search(

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -213,7 +213,7 @@ export class Resonate {
     if (!this.cache.has(id)) {
       const promise = new Promise(async (resolve, reject) => {
         // lock
-        while (!await store.locks.tryAcquire(id, this.pid, opts.eid)) {
+        while (!(await store.locks.tryAcquire(id, this.pid, opts.eid))) {
           // sleep
           await new Promise((r) => setTimeout(r, 1000));
         }

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -208,12 +208,12 @@ export class Resonate {
     id = this.id(this.namespace, name, opts.id ?? id);
     const idempotencyKey = opts.idempotencyKey ?? id;
 
-    const locks = this.store(opts.store).locks;
+    const store = this.store(opts.store);
 
     if (!this.cache.has(id)) {
       const promise = new Promise(async (resolve, reject) => {
         // lock
-        while (!locks.tryAcquire(id, this.pid, opts.eid)) {
+        while (!await store.locks.tryAcquire(id, this.pid, opts.eid)) {
           // sleep
           await new Promise((r) => setTimeout(r, 1000));
         }
@@ -225,7 +225,7 @@ export class Resonate {
         } catch (e) {
           reject(e);
         } finally {
-          locks.release(id, opts.eid);
+          await store.locks.release(id, opts.eid);
         }
       });
 

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -1,8 +1,6 @@
 import { jest, describe, test, expect } from "@jest/globals";
 import { Resonate, Context } from "../lib/resonate";
 import { LocalStore } from "../lib/core/stores/local";
-import { MemoryStorage } from "../lib/core/storages/memory";
-import { Lock } from "../lib/core/lock";
 
 // Set a larger timeout for hooks (e.g., 10 seconds)
 jest.setTimeout(10000);

--- a/test/lock.test.ts
+++ b/test/lock.test.ts
@@ -1,7 +1,8 @@
 import { jest, describe, test, expect } from "@jest/globals";
 import { Resonate, Context } from "../lib/resonate";
 import { LocalStore } from "../lib/core/stores/local";
-import { MemoryLockStore } from "../lib/core/storages/memory";
+import { MemoryStorage } from "../lib/core/storages/memory";
+import { Lock } from "../lib/core/lock";
 
 // Set a larger timeout for hooks (e.g., 10 seconds)
 jest.setTimeout(10000);
@@ -19,7 +20,7 @@ function write(context: Context, id: string, final: boolean = false) {
 }
 
 describe("Lock", () => {
-  const store = new LocalStore(undefined, undefined, undefined, new MemoryLockStore());
+  const store = new LocalStore();
   const r1 = new Resonate({ store });
   const r2 = new Resonate({ store });
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -69,8 +69,7 @@ describe("LocalPromiseStore", () => {
     expect(searchResults.id).toBe(scheduleId);
 
     const isDeleted = await store.schedules.delete(scheduleId);
-
-    expect(isDeleted).toBe(true);
+    expect(isDeleted).toBeUndefined();
 
     // search for the schedule again
     let schedules: Schedule[] = [];


### PR DESCRIPTION
```ts
export interface IStore {
  readonly promises: IPromiseStore;
  readonly schedules: IScheduleStore;
  readonly locks: ILockStore;
}

export interface IStorage<T> {
  rmw<X extends T | undefined>(id: string, func: (item: T | undefined) => X): Promise<X>;
  rmd(id: string, func: (item: T) => boolean): Promise<void>;
  all(): AsyncGenerator<T[], void>;
}
```

The local store components can be implemented as
```ts
IStorage<DurablePromise>
IStorage<Schedule>
IStorage<Lock>
```

And the actual implementation ca be implemented using these storage primitives, consolidating the business logic in the `LocalStore`.