### PR TITLE
Add get accessor for default schedule store

### DIFF
--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -1,5 +1,5 @@
 import { Opts } from "./core/opts";
-import { IStore } from "./core/store";
+import { IStore, IScheduleStore } from "./core/store";
 import { DurablePromise, isPendingPromise, isResolvedPromise } from "./core/promise";
 import { Retry } from "./core/retries/retry";
 import { IBucket } from "./core/bucket";
@@ -139,6 +139,15 @@ export class Resonate {
    */
   bucket(name: string): IBucket {
     return this.buckets[name];
+  }
+
+  /**
+   * The default schedule store.
+   *
+   * @returns instance of IScheduleStore
+   */
+  get schedules(): IScheduleStore {
+    return this.stores["default"].schedules;
   }
 
   /**


### PR DESCRIPTION
```ts

const resonate = new Resonate();

resonate.schedules.create(...);
resonate.schedules.get(...);
resonate.schedules.delete(...);

```