### PR TITLE
Add durable and lock options

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -146,6 +146,13 @@ export class Context {
   }
 
   /**
+   * All configured options for this context.
+   */
+  get opts() {
+    return this.invocation.opts;
+  }
+
+  /**
    * The timestamp in ms, once this time elapses the function invocation will timeout.
    */
   get timeout() {

--- a/lib/async.ts
+++ b/lib/async.ts
@@ -218,7 +218,7 @@ export class Context {
     const param = typeof func === "string" ? args[0] : undefined;
 
     // create a new invocation
-    const invocation = new Invocation(name, id, undefined, param, opts, defaults, undefined, parent);
+    const invocation = new Invocation(name, id, undefined, param, opts, defaults, parent);
 
     let execution: Execution<any>;
     if (typeof func === "string") {
@@ -419,11 +419,8 @@ class Scheduler {
       args,
     };
 
-    // if a durable promise already exists, this timeout takes precedence
-    const timeout = durablePromise?.timeout;
-
     // create a new invocation
-    const invocation = new Invocation<Return<F>>(name, id, undefined, param, opts, defaults, timeout);
+    const invocation = new Invocation<Return<F>>(name, id, undefined, param, opts, defaults);
 
     // create a new execution
     const ctx = new Context(this.resonate, invocation);

--- a/lib/async.ts
+++ b/lib/async.ts
@@ -398,7 +398,7 @@ class Scheduler {
   ): ResonatePromise<Return<F>> {
     // if the execution is already running, and not killed,
     // return the promise
-    if (this.cache[id] && !this.cache[id].killed) {
+    if (opts.durable && this.cache[id] && !this.cache[id].killed) {
       // execute is idempotent
       return this.cache[id].execute();
     }

--- a/lib/core/execution.ts
+++ b/lib/core/execution.ts
@@ -117,7 +117,7 @@ export class OrdinaryExecution<T> extends Execution<T> {
   private async run(): Promise<T> {
     // acquire lock if necessary
     while (
-      this.invocation.lock &&
+      this.invocation.opts.lock &&
       !(await this.resonate.store.locks.tryAcquire(this.invocation.id, this.invocation.eid))
     ) {
       await new Promise((resolve) => setTimeout(resolve, this.invocation.opts.poll));
@@ -125,7 +125,7 @@ export class OrdinaryExecution<T> extends Execution<T> {
 
     return this._run().finally(async () => {
       // release lock if necessary
-      if (this.invocation.lock) {
+      if (this.invocation.opts.lock) {
         try {
           await this.resonate.store.locks.release(this.invocation.id, this.invocation.eid);
         } catch (e) {
@@ -205,7 +205,7 @@ export class GeneratorExecution<T> extends Execution<T> {
 
     // TODO
     // For the time being we can only acquire a lock for the generator execution
-    // if it is the root invocation. This is because we "stop the world" to create
+    // if it is the root execution. This is because we "stop the world" to create
     // a durable promise, which currently includes acquiring a lock. This could
     // cause the event loop to deadlock.
     this.lock = this.invocation.parent ? false : this.invocation.opts.lock ?? false;

--- a/lib/core/execution.ts
+++ b/lib/core/execution.ts
@@ -211,7 +211,6 @@ export class GeneratorExecution<T> extends Execution<T> {
     if (this.invocation.opts.durable) {
       // create a durable promise if the invocation is durable
       try {
-        // create a durable promise
         this.durablePromise = await DurablePromise.create<T>(
           this.invocation.opts.store.promises,
           this.invocation.opts.encoder,
@@ -251,7 +250,6 @@ export class GeneratorExecution<T> extends Execution<T> {
     if (this.durablePromise) {
       // resolve the durable promise if the invocation is durable
       try {
-        // resolve the durable promise
         await this.durablePromise.resolve(value, { idempotencyKey: this.invocation.idempotencyKey });
 
         // resolve/reject the invocation
@@ -283,7 +281,6 @@ export class GeneratorExecution<T> extends Execution<T> {
     if (this.durablePromise) {
       // reject the durable promise if the invocation is durable
       try {
-        // reject the durable promise
         await this.durablePromise.reject(error, { idempotencyKey: this.invocation.idempotencyKey });
 
         // resolve/reject the invocation

--- a/lib/core/future.ts
+++ b/lib/core/future.ts
@@ -108,6 +108,14 @@ export class Future<T> {
     return this._value;
   }
 
+  get pending() {
+    return this._value.kind === "pending";
+  }
+
+  get completed() {
+    return !this.pending;
+  }
+
   private resolve(value: T) {
     this._resolve(value);
     this._value = { kind: "resolved", value };

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -99,14 +99,12 @@ export class Invocation<T> {
         tags: { ...this.defaults.tags, ...opts.tags }, // tags are merged
       };
     } else {
-      opts = this.defaults;
+      // copy defaults
+      opts = { ...this.defaults };
     }
 
     // lock is false by default
     opts.lock = opts.lock ?? false;
-
-    // if durable is false, disable lock
-    opts.lock = opts.durable ? opts.lock : false;
 
     // version cannot be overridden
     opts.version = this.defaults.version;

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -1,6 +1,5 @@
 import { Future } from "./future";
 import { Options, PartialOptions, isOptions } from "./options";
-import * as utils from "./utils";
 
 /////////////////////////////////////////////////////////////////////
 // Invocation
@@ -84,12 +83,6 @@ export class Invocation<T> {
 
     // by default, lock is only applied to the root
     defaults.lock = false;
-
-    // if idempotencyKey is overriden on the root with a string,
-    // revert to hash function
-    if (typeof defaults.idempotencyKey === "string") {
-      defaults.idempotencyKey = utils.hash;
-    }
 
     // merge opts
     if (isOptions(opts)) {

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -43,7 +43,6 @@ export class Invocation<T> {
     public readonly param: unknown,
     public readonly opts: Options,
     public readonly defaults: Options,
-    timeout?: number,
     parent?: Invocation<any>,
   ) {
     // create a future and hold on to its resolvers
@@ -66,12 +65,10 @@ export class Invocation<T> {
     this.idempotencyKey =
       typeof this.opts.idempotencyKey === "function" ? this.opts.idempotencyKey(this.id) : this.opts.idempotencyKey;
 
-    // calculate the timeout, which is either:
-    // - a hard coded number, this is passed in when a durable promise already exists
-    // - min of:
-    //   - the current time plus the user provided relative time
-    //   - the parent timeout
-    this.timeout = timeout ?? Math.min(this.createdAt + this.opts.timeout, this.parent?.timeout ?? Infinity);
+    // the timeout is the minimum of:
+    // - the current time plus the user provided relative time
+    // - the parent timeout
+    this.timeout = Math.min(this.createdAt + this.opts.timeout, this.parent?.timeout ?? Infinity);
   }
 
   addChild(child: Invocation<any>) {

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -11,6 +11,9 @@ export class Invocation<T> {
   resolve: (v: T) => void;
   reject: (e: unknown) => void;
 
+  idempotencyKey: string | undefined;
+  timeout: number;
+
   killed: boolean = false;
 
   createdAt: number = Date.now();
@@ -48,16 +51,11 @@ export class Invocation<T> {
 
     this.root = parent?.root ?? this;
     this.parent = parent ?? null;
-  }
 
-  get idempotencyKey(): string | undefined {
-    return typeof this.opts.idempotencyKey === "function"
-      ? this.opts.idempotencyKey(this.id)
-      : this.opts.idempotencyKey;
-  }
+    this.idempotencyKey =
+      typeof this.opts.idempotencyKey === "function" ? this.opts.idempotencyKey(this.id) : this.opts.idempotencyKey;
 
-  get timeout(): number {
-    return Math.min(this.createdAt + this.opts.timeout, this.parent?.timeout ?? Infinity);
+    this.timeout = Math.min(this.createdAt + this.opts.timeout, this.parent?.timeout ?? Infinity);
   }
 
   addChild(child: Invocation<any>) {

--- a/lib/core/options.ts
+++ b/lib/core/options.ts
@@ -73,14 +73,29 @@ export type Options = {
   durable: boolean;
 
   /**
+   * A unique id for this execution, defaults to a random id.
+   */
+  eid: string;
+
+  /**
    * Overrides the default encoder.
    */
   encoder: IEncoder<unknown, string | undefined>;
 
   /**
+   * Overrides the default idempotency key.
+   */
+  idempotencyKey: string | ((id: string) => string) | undefined;
+
+  /**
    * Acquire a lock for the execution.
    */
   lock: boolean;
+
+  /**
+   * Overrides the default logger.
+   */
+  logger: ILogger;
 
   /**
    * Overrides the default polling frequency.

--- a/lib/core/options.ts
+++ b/lib/core/options.ts
@@ -68,9 +68,19 @@ export type Options = {
   __resonate: true;
 
   /**
+   * Persist the result to durable storage.
+   */
+  durable: boolean;
+
+  /**
    * Overrides the default encoder.
    */
   encoder: IEncoder<unknown, string | undefined>;
+
+  /**
+   * Acquire a lock for the execution.
+   */
+  lock: boolean;
 
   /**
    * Overrides the default polling frequency.

--- a/lib/core/options.ts
+++ b/lib/core/options.ts
@@ -93,11 +93,6 @@ export type Options = {
   lock: boolean;
 
   /**
-   * Overrides the default logger.
-   */
-  logger: ILogger;
-
-  /**
    * Overrides the default polling frequency.
    */
   poll: number;
@@ -106,11 +101,6 @@ export type Options = {
    * Overrides the default retry policy.
    */
   retry: IRetry;
-
-  /**
-   * Overrides the default store.
-   */
-  store: IStore;
 
   /**
    * Additional tags to add to the durable promise.

--- a/lib/core/options.ts
+++ b/lib/core/options.ts
@@ -75,7 +75,7 @@ export type Options = {
   /**
    * A unique id for this execution, defaults to a random id.
    */
-  eid: string;
+  eid: string | ((id: string) => string);
 
   /**
    * Overrides the default encoder.
@@ -85,12 +85,12 @@ export type Options = {
   /**
    * Overrides the default idempotency key.
    */
-  idempotencyKey: string | ((id: string) => string) | undefined;
+  idempotencyKey: string | ((id: string) => string);
 
   /**
    * Acquire a lock for the execution.
    */
-  lock: boolean;
+  lock: boolean | undefined;
 
   /**
    * Overrides the default polling frequency.

--- a/lib/core/promises/promises.ts
+++ b/lib/core/promises/promises.ts
@@ -124,7 +124,7 @@ export class DurablePromise<T> {
         opts.strict ?? false,
         opts.headers,
         encoder.encode(opts.param),
-        Date.now() + timeout,
+        timeout,
         opts.tags,
       ),
       opts.poll,

--- a/lib/core/promises/promises.ts
+++ b/lib/core/promises/promises.ts
@@ -53,6 +53,10 @@ export class DurablePromise<T> {
     return this.promise.idempotencyKeyForComplete;
   }
 
+  get timeout() {
+    return this.promise.timeout;
+  }
+
   get pending() {
     return this.promise.state === "PENDING";
   }

--- a/lib/core/store.ts
+++ b/lib/core/store.ts
@@ -189,9 +189,10 @@ export interface ILockStore {
    *
    * @param id Id of lock.
    * @param eid Execution id of lock.
+   * @param expiry Time in ms before lock will expire.
    * @returns A boolean indicating whether or not the lock was acquired.
    */
-  tryAcquire(id: string, eid: string): Promise<boolean>;
+  tryAcquire(id: string, eid: string, expiry?: number): Promise<boolean>;
 
   /**
    * Release a lock.

--- a/lib/core/store.ts
+++ b/lib/core/store.ts
@@ -200,5 +200,5 @@ export interface ILockStore {
    * @param id Id of lock.
    * @param eid Execution id of lock.
    */
-  release(id: string, eid: string): Promise<void>;
+  release(id: string, eid: string): Promise<boolean>;
 }

--- a/lib/core/stores/local.ts
+++ b/lib/core/stores/local.ts
@@ -475,14 +475,16 @@ export class LocalLockStore implements ILockStore {
       throw new ResonateError("Forbidden request", ErrorCodes.STORE_FORBIDDEN);
     }
 
-    return lock.eid === eid;
+    return true;
   }
 
-  async release(id: string, eid: string) {
+  async release(id: string, eid: string): Promise<boolean> {
     const result = await this.storage.rmd(id, (lock) => lock.eid === eid);
     if (!result) {
       throw new ResonateError("Not found", ErrorCodes.STORE_NOT_FOUND);
     }
+
+    return true;
   }
 }
 

--- a/lib/core/stores/remote.ts
+++ b/lib/core/stores/remote.ts
@@ -26,10 +26,11 @@ export class RemoteStore implements IStore {
     pid: string,
     logger: ILogger = new Logger(),
     encoder: IEncoder<string, string> = new Base64Encoder(),
+    heartbeatFrequency?: number,
   ) {
     this.promises = new RemotePromiseStore(url, logger, encoder);
     this.schedules = new RemoteScheduleStore(url, logger, encoder);
-    this.locks = new RemoteLockStore(url, pid, logger);
+    this.locks = new RemoteLockStore(url, pid, logger, heartbeatFrequency);
   }
 }
 
@@ -389,19 +390,23 @@ export class RemoteScheduleStore implements IScheduleStore {
 }
 
 export class RemoteLockStore implements ILockStore {
-  private heartbeatDelay: number;
-  private hearbeatInterval: number | null = null;
+  private heartbeatInterval: number | null = null;
 
   constructor(
     private url: string,
     private pid: string,
     private logger: ILogger = new Logger(),
-    private lockTimeout: number = 60000,
-  ) {
-    this.heartbeatDelay = this.lockTimeout / 4;
-  }
+    private heartbeatFrequency: number = 15000,
+  ) {}
 
-  async tryAcquire(resourceId: string, executionId: string): Promise<boolean> {
+  async tryAcquire(
+    resourceId: string,
+    executionId: string,
+    expiry: number = this.heartbeatFrequency * 4,
+  ): Promise<boolean> {
+    // lock expiry cannot be less than heartbeat frequency
+    expiry = Math.max(expiry, this.heartbeatFrequency);
+
     const acquired = call<boolean>(
       `${this.url}/locks/acquire`,
       (b: unknown): b is any => true,
@@ -411,7 +416,7 @@ export class RemoteLockStore implements ILockStore {
           resourceId: resourceId,
           processId: this.pid,
           executionId: executionId,
-          expiryInMilliseconds: this.lockTimeout,
+          expiryInMilliseconds: expiry,
         }),
       },
       this.logger,
@@ -446,16 +451,16 @@ export class RemoteLockStore implements ILockStore {
   }
 
   private startHeartbeat(): void {
-    if (this.hearbeatInterval === null) {
+    if (this.heartbeatInterval === null) {
       // the + converts to a number
-      this.hearbeatInterval = +setInterval(() => this.heartbeat(), this.heartbeatDelay);
+      this.heartbeatInterval = +setInterval(() => this.heartbeat(), this.heartbeatFrequency);
     }
   }
 
   private stopHeartbeat(): void {
-    if (this.hearbeatInterval !== null) {
-      clearInterval(this.hearbeatInterval);
-      this.hearbeatInterval = null;
+    if (this.heartbeatInterval !== null) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
     }
   }
 

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -174,6 +174,13 @@ export class Info {
   }
 
   /**
+   * All configured options for this info.
+   */
+  get opts() {
+    return this.invocation.opts;
+  }
+
+  /**
    * The timestamp in ms, once this time elapses the function invocation will timeout.
    */
   get timeout() {
@@ -210,6 +217,13 @@ export class Context {
    */
   get idempotencyKey() {
     return this.invocation.idempotencyKey;
+  }
+
+  /**
+   * All configured options for this context.
+   */
+  get opts() {
+    return this.invocation.opts;
   }
 
   /**

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -376,11 +376,8 @@ class Scheduler {
       args,
     };
 
-    // if a durable promise already exists, this timeout takes precedence
-    const timeout = durablePromise?.timeout;
-
     // create a new invocation
-    const invocation = new Invocation(name, id, undefined, param, opts, defaults, timeout);
+    const invocation = new Invocation(name, id, undefined, param, opts, defaults);
 
     // create a new execution
     const generator = func(new Context(invocation), ...args);
@@ -508,7 +505,7 @@ class Scheduler {
     const param = value.kind === "deferred" ? value.args[0] : undefined;
 
     // create a new invocation
-    const invocation = new Invocation(name, id, undefined, param, value.opts, defaults, undefined, parent);
+    const invocation = new Invocation(name, id, undefined, param, value.opts, defaults, parent);
 
     // add child and increment counter
     parent.addChild(invocation);

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -107,7 +107,6 @@ export abstract class ResonateBase {
   protected abstract execute(
     name: string,
     id: string,
-    // idempotencyKey: string | undefined,
     func: Func,
     args: any[],
     opts: Options,
@@ -139,7 +138,6 @@ export abstract class ResonateBase {
 
     // register specific version
     this.functions[name][options.version] = { func, opts: options };
-
     return (id: string, ...args: any[]) => this.run(name, id, ...args, options);
   }
 

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -104,13 +104,7 @@ export abstract class ResonateBase {
     };
   }
 
-  protected abstract execute(
-    name: string,
-    id: string,
-    func: Func,
-    args: any[],
-    opts: Options,
-  ): ResonatePromise<any>;
+  protected abstract execute(name: string, id: string, func: Func, args: any[], opts: Options): ResonatePromise<any>;
 
   register(name: string, func: Func, opts: Partial<Options> = {}): (id: string, ...args: any) => ResonatePromise<any> {
     // set default version

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -289,9 +289,6 @@ export abstract class ResonateBase {
     // merge tags
     tags = { ...this.tags, ...tags };
 
-    // if durable is false, disable lock
-    lock = durable ? lock : false;
-
     return {
       __resonate: true,
       eid,

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -238,7 +238,9 @@ export abstract class ResonateBase {
   }
 
   private defaults({
+    durable = true,
     encoder = this.encoder,
+    lock = true,
     poll = this.poll,
     retry = this.retry,
     store = this.store,
@@ -251,7 +253,9 @@ export abstract class ResonateBase {
 
     return {
       __resonate: true,
+      durable,
       encoder,
+      lock,
       poll,
       retry,
       store,

--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -176,21 +176,21 @@ export abstract class ResonateBase {
     // in the durable promise and therefore not required on the recovery path
     const override: Partial<Options> = {};
 
-    if (durable) {
+    if (durable !== undefined) {
       override.durable = durable;
     }
 
-    if (idempotencyKey) {
+    if (idempotencyKey !== undefined) {
       override.idempotencyKey = idempotencyKey;
     }
 
-    if (tags) {
+    if (tags !== undefined) {
       override.tags = { ...defaults.tags, ...tags, "resonate:invocation": "true" };
     } else {
-      override.tags = { "resonate:invocation": "true" };
+      override.tags = { ...defaults.tags, "resonate:invocation": "true" };
     }
 
-    if (timeout) {
+    if (timeout !== undefined) {
       override.timeout = timeout;
     }
 
@@ -199,6 +199,9 @@ export abstract class ResonateBase {
       ...defaults,
       ...override,
     };
+
+    // lock on top level is true by default
+    opts.lock = opts.lock ?? true;
 
     return this.execute(name, id, func, args, opts, defaults);
   }

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -50,7 +50,7 @@ describe("Functions: async", () => {
     resonate.register("successAsync", ordinarySuccessAsync);
 
     // pre-resolve deferred
-    const deferred = await resonate.promises.create("success", 1000, {
+    const deferred = await resonate.promises.create("success", Date.now() + 1000, {
       idempotencyKey: utils.hash("success"),
     });
     deferred.resolve("foo");
@@ -79,7 +79,7 @@ describe("Functions: async", () => {
     resonate.register("failureAsync", ordinaryFailureAsync);
 
     // pre-reject deferred
-    const deferred = await resonate.promises.create("failure", 1000, {
+    const deferred = await resonate.promises.create("failure", Date.now() + 1000, {
       idempotencyKey: utils.hash("failure"),
     });
     deferred.reject(new Error("foo"));

--- a/test/durable.test.ts
+++ b/test/durable.test.ts
@@ -1,0 +1,82 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import * as a from "../lib/async";
+import * as g from "../lib/generator";
+
+jest.setTimeout(10000);
+
+describe("Functions: versions", () => {
+  const rA = new a.Resonate();
+  rA.register("default", async (ctx: a.Context, val: string) => {
+    return await ctx.run(() => val);
+  });
+  rA.register(
+    "durable",
+    async (ctx: a.Context, val: string) => {
+      return await ctx.run(() => val, ctx.options({ durable: true }));
+    },
+    { durable: false },
+  );
+  rA.register(
+    "volatile",
+    async (ctx: a.Context, val: string) => {
+      return await ctx.run(() => val, ctx.options({ durable: false }));
+    },
+    { durable: false },
+  );
+
+  const rG = new g.Resonate();
+  rG.register("default", function* (ctx: g.Context, val: string) {
+    return yield ctx.run(function* () {
+      return val;
+    });
+  });
+  rG.register(
+    "durable",
+    function* (ctx: g.Context, val: string) {
+      return yield ctx.run(
+        function* () {
+          return val;
+        },
+        ctx.options({ durable: true }),
+      );
+    },
+    { durable: false },
+  );
+  rG.register(
+    "volatile",
+    function* (ctx: g.Context, val: string) {
+      return yield ctx.run(
+        function* () {
+          return val;
+        },
+        ctx.options({ durable: false }),
+      );
+    },
+    { durable: false },
+  );
+
+  for (const { name, resonate } of [
+    { name: "async", resonate: rA },
+    { name: "generator", resonate: rG },
+  ]) {
+    describe(name, () => {
+      test("default should be durable", async () => {
+        expect(await resonate.run("default", "default.a", "a")).toBe("a");
+        expect(await resonate.run("default", "default.a", "b")).toBe("a");
+        expect(await resonate.run("default", "default.b", "b")).toBe("b");
+      });
+
+      test("durable should be durable", async () => {
+        expect(await resonate.run("durable", "durable.a", "a")).toBe("a");
+        expect(await resonate.run("durable", "durable.a", "b")).toBe("a");
+        expect(await resonate.run("durable", "durable.b", "b")).toBe("b");
+      });
+
+      test("volatile should not be durable", async () => {
+        expect(await resonate.run("volatile", "volatile.a", "a")).toBe("a");
+        expect(await resonate.run("volatile", "volatile.a", "b")).toBe("b");
+        expect(await resonate.run("volatile", "volatile.b", "b")).toBe("b");
+      });
+    });
+  }
+});

--- a/test/generator.test.ts
+++ b/test/generator.test.ts
@@ -62,7 +62,7 @@ describe("Functions: generator", () => {
     resonate.register("success", generatorSuccess);
 
     // pre-resolve deferred
-    const deferred = await resonate.promises.create("success", 1000, {
+    const deferred = await resonate.promises.create("success", Date.now() + 1000, {
       idempotencyKey: utils.hash("success"),
     });
     deferred.resolve("foo");
@@ -100,7 +100,7 @@ describe("Functions: generator", () => {
     resonate.register("failure", generatorFailure);
 
     // pre-reject deferred
-    const deferred = await resonate.promises.create("failure", 1000, {
+    const deferred = await resonate.promises.create("failure", Date.now() + 1000, {
       idempotencyKey: utils.hash("failure"),
     });
     deferred.reject(new Error("foo"));

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -1,0 +1,222 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import * as a from "../lib/async";
+import { Base64Encoder } from "../lib/core/encoders/base64";
+import { JSONEncoder } from "../lib/core/encoders/json";
+import { Options } from "../lib/core/options";
+import { Retry } from "../lib/core/retries/retry";
+import * as utils from "../lib/core/utils";
+import * as g from "../lib/generator";
+
+jest.setTimeout(10000);
+
+async function aTest(ctx: a.Context, opts: Partial<Options> = {}) {
+  return [
+    ctx.opts,
+    ...(await ctx.run(
+      async (ctx: a.Context) => [ctx.opts, await ctx.run((ctx: a.Context) => ctx.opts)],
+      ctx.options(opts),
+    )),
+  ];
+}
+
+function* gTest(ctx: g.Context, opts: Partial<Options> = {}) {
+  const o: [Options, Options] = yield ctx.run(function* (ctx: g.Context) {
+    return [
+      ctx.opts,
+      yield ctx.run(function* (ctx: g.Context) {
+        return ctx.opts;
+      }),
+    ];
+  }, ctx.options(opts));
+
+  return [ctx.opts, ...o];
+}
+
+describe("Options", () => {
+  const resonateOpts = {
+    encoder: new JSONEncoder(),
+    poll: 1000,
+    retry: Retry.exponential(),
+    tags: { a: "a", b: "b", c: "c" },
+    timeout: 1000,
+  };
+
+  const overrides = {
+    durable: false,
+    eid: "eid",
+    encoder: new Base64Encoder(),
+    idempotencyKey: "idempotencyKey",
+    lock: false,
+    poll: 2000,
+    retry: Retry.linear(),
+    tags: { c: "x", d: "d", e: "e" },
+    timeout: 2000,
+    version: 2,
+  };
+
+  const rA = new a.Resonate(resonateOpts);
+  rA.register("test.1", aTest, { durable: false });
+  rA.register("test.1", aTest, { durable: false, version: 2 });
+  rA.register("test.1", aTest, { version: 3 });
+  rA.register("test.2", aTest, overrides);
+
+  const rG = new g.Resonate(resonateOpts);
+  rG.register("test.1", gTest, { durable: false });
+  rG.register("test.1", gTest, { durable: false, version: 2 });
+  rG.register("test.1", gTest, { version: 3 });
+  rG.register("test.2", gTest, overrides);
+
+  for (const { name, resonate } of [
+    { name: "async", resonate: rA },
+    // { name: "generator", resonate: rG },
+  ]) {
+    describe(name, () => {
+      test("resonate default options propagate down", async () => {
+        const [top, middle, bottom] = await resonate.run<[Options, Options, Options]>(
+          "test.1",
+          `test.1.${name}.1`,
+          resonate.options({ version: 1 }),
+        );
+
+        for (const opts of [top, middle, bottom]) {
+          expect(opts.durable).toBe(false);
+          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.encoder).toBe(resonateOpts.encoder);
+          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.lock).toBe(false);
+          expect(opts.poll).toBe(resonateOpts.poll);
+          expect(opts.retry).toBe(resonateOpts.retry);
+          expect(opts.timeout).toBe(resonateOpts.timeout);
+          expect(opts.version).toBe(1);
+        }
+
+        expect(top.tags).toEqual({ ...resonateOpts.tags, "resonate:invocation": "true" });
+        expect(middle.tags).toEqual(resonateOpts.tags);
+        expect(bottom.tags).toEqual(resonateOpts.tags);
+      });
+
+      test("registered options propagate down", async () => {
+        const [top, middle, bottom] = await resonate.run<[Options, Options, Options]>("test.2", `test.2.${name}.1`);
+
+        for (const opts of [top, middle, bottom]) {
+          expect(opts.durable).toBe(overrides.durable);
+          expect(opts.eid).toBe(overrides.eid);
+          expect(opts.encoder).toBe(overrides.encoder);
+          expect(opts.idempotencyKey).toBe(overrides.idempotencyKey);
+          expect(opts.lock).toBe(overrides.lock);
+          expect(opts.poll).toBe(overrides.poll);
+          expect(opts.retry).toBe(overrides.retry);
+          expect(opts.timeout).toBe(overrides.timeout);
+          expect(opts.version).toBe(overrides.version);
+        }
+
+        expect(top.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags, "resonate:invocation": "true" });
+        expect(middle.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags });
+        expect(bottom.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags });
+      });
+
+      test("options passed to resonate run affect top level only", async () => {
+        const [top, ...bottom] = await resonate.run<[Options, Options, Options]>(
+          "test.1",
+          `test.1.${name}.2`,
+          resonate.options(overrides),
+        );
+
+        // top level options
+        expect(top.durable).toBe(false);
+        expect(top.eid).toBe(utils.randomId);
+        expect(top.encoder).toBe(resonateOpts.encoder);
+        expect(top.idempotencyKey).toBe(overrides.idempotencyKey);
+        expect(top.lock).toBe(false);
+        expect(top.poll).toBe(resonateOpts.poll);
+        expect(top.retry).toBe(resonateOpts.retry);
+        expect(top.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags, "resonate:invocation": "true" });
+        expect(top.timeout).toBe(overrides.timeout);
+        expect(top.version).toBe(overrides.version);
+
+        // bottom level options
+        for (const opts of bottom) {
+          expect(opts.durable).toBe(false);
+          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.encoder).toBe(resonateOpts.encoder);
+          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.lock).toBe(false);
+          expect(opts.poll).toBe(resonateOpts.poll);
+          expect(opts.retry).toBe(resonateOpts.retry);
+          expect(opts.tags).toEqual(resonateOpts.tags);
+          expect(opts.timeout).toBe(resonateOpts.timeout);
+          expect(opts.version).toBe(overrides.version);
+        }
+      });
+
+      test("options passed to context run affect current level only", async () => {
+        const [top, middle, bottom] = await resonate.run<[Options, Options, Options]>(
+          "test.1",
+          `test.1.${name}.3`,
+          overrides,
+          resonate.options({ version: 1 }),
+        );
+
+        // middle options (overriden)
+        expect(middle.durable).toBe(overrides.durable);
+        expect(middle.eid).toBe(overrides.eid);
+        expect(middle.encoder).toBe(overrides.encoder);
+        expect(middle.idempotencyKey).toBe(overrides.idempotencyKey);
+        expect(middle.lock).toBe(overrides.lock);
+        expect(middle.poll).toBe(overrides.poll);
+        expect(middle.retry).toBe(overrides.retry);
+        expect(middle.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags });
+        expect(middle.timeout).toBe(overrides.timeout);
+        expect(middle.version).toBe(1);
+
+        // top and bottom options
+        for (const opts of [top, bottom]) {
+          expect(opts.durable).toBe(false);
+          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.encoder).toBe(resonateOpts.encoder);
+          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.lock).toBe(false);
+          expect(opts.poll).toBe(resonateOpts.poll);
+          expect(opts.retry).toBe(resonateOpts.retry);
+          expect(opts.timeout).toBe(resonateOpts.timeout);
+          expect(opts.version).toBe(1);
+        }
+
+        expect(top.tags).toEqual({ ...resonateOpts.tags, "resonate:invocation": "true" });
+        expect(bottom.tags).toEqual(resonateOpts.tags);
+      });
+
+      test("only top level is locked by default", async () => {
+        const [top, middle, bottom] = await resonate.run<[Options, Options, Options]>(
+          "test.1",
+          `test.1.${name}.4`,
+          resonate.options({ version: 3 }),
+        );
+
+        expect(top.lock).toBe(true);
+        expect(middle.lock).toBe(false);
+        expect(bottom.lock).toBe(false);
+
+        expect(top.durable).toBe(true);
+        expect(middle.durable).toBe(true);
+        expect(bottom.durable).toBe(true);
+      });
+
+      test("non durable disables locking", async () => {
+        const [top, middle, bottom] = await resonate.run<[Options, Options, Options]>(
+          "test.1",
+          `test.1.${name}.5`,
+          resonate.options({ durable: false, lock: true, version: 3 }),
+        );
+
+        expect(top.durable).toBe(false);
+        expect(middle.durable).toBe(true);
+        expect(bottom.durable).toBe(true);
+
+        expect(top.lock).toBe(false);
+        expect(middle.lock).toBe(false);
+        expect(bottom.lock).toBe(false);
+      });
+    });
+  }
+});

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -52,7 +52,7 @@ describe("Functions: versions", () => {
         expect(r2).toMatchObject({ v: "v3", c: 3 });
 
         const r3 = await resonate.run("test", "e");
-        expect(r2).toMatchObject({ v: "v3", c: 3 });
+        expect(r3).toMatchObject({ v: "v3", c: 3 });
       });
     });
   }

--- a/test/versions.test.ts
+++ b/test/versions.test.ts
@@ -48,7 +48,10 @@ describe("Functions: versions", () => {
         const r1 = await resonate.run("test", "c", resonate.options({ version: 3 }));
         expect(r1).toMatchObject({ v: "v3", c: 3 });
 
-        const r2 = await resonate.run("test", "d");
+        const r2 = await resonate.run("test", "d", resonate.options({ version: 0 }));
+        expect(r2).toMatchObject({ v: "v3", c: 3 });
+
+        const r3 = await resonate.run("test", "e");
         expect(r2).toMatchObject({ v: "v3", c: 3 });
       });
     });


### PR DESCRIPTION
| option | default | behaviour |
| --- | --- | --- |
| durable | true | represent the execution as a durable promise |
| lock | true | acquire a lock before invoking a function |
| eid | `utils.randomId` | a unique execution id, can be a function or a string, used when acquiring a lock |
| idempotencyKey | `utils.hash` | can be a function or a string, defaults to a simple hash function |