### PR TITLE
Fix created promise on ResonatePromise

### DIFF
--- a/lib/core/future.ts
+++ b/lib/core/future.ts
@@ -23,7 +23,7 @@ export class ResonatePromise<T> extends Promise<T> {
    */
   constructor(
     public id: string,
-    created: Promise<any>,
+    created: Promise<Future<T>>,
     completed: Promise<T>,
   ) {
     // bind the promise to the completed promise
@@ -32,7 +32,7 @@ export class ResonatePromise<T> extends Promise<T> {
     });
 
     // expose the id when the durable promise has been created
-    this.created = created.then(() => this.id);
+    this.created = created.then((future) => future.id);
   }
 }
 

--- a/lib/core/promises/promises.ts
+++ b/lib/core/promises/promises.ts
@@ -19,7 +19,6 @@ export type CompleteOptions = {
 };
 
 export class DurablePromise<T> {
-  readonly created: Promise<DurablePromise<T>>;
   readonly completed: Promise<DurablePromise<T>>;
   private complete!: (value: DurablePromise<T>) => void;
 
@@ -31,7 +30,6 @@ export class DurablePromise<T> {
     private promise: PendingPromise | ResolvedPromise | RejectedPromise | CanceledPromise | TimedoutPromise,
     poll?: number,
   ) {
-    this.created = Promise.resolve(this);
     this.completed = new Promise((resolve) => {
       this.complete = resolve;
     });


### PR DESCRIPTION
ResonatePromise extends a javascript promise and exposes created to signal when the durable promise has been created on the server. This fix ensures fork does not prematurely await, which caused the created promise to unnecessarily be delayed until the promise was completed.