### PR TITLE
Add createdOn time to context

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -132,6 +132,13 @@ export class Context {
   }
 
   /**
+   * The time the invocation was created. Will use the durable promise creation time if available.
+   */
+  get createdOn() {
+    return this.invocation.createdOn;
+  }
+
+  /**
    * Uniquely identifies the function invocation.
    */
   get id() {

--- a/lib/core/execution.ts
+++ b/lib/core/execution.ts
@@ -107,13 +107,18 @@ export class OrdinaryExecution<T> extends Execution<T> {
               tags: this.invocation.opts.tags,
             },
           ));
-
-        // override the invocation timeout
-        this.invocation.timeout = this.durablePromise.timeout;
       } catch (e) {
         // if an error occurs, kill the execution
         this.kill(e);
       }
+    }
+
+    if (this.durablePromise) {
+      // override the invocation creation time
+      this.invocation.createdOn = this.durablePromise.createdOn;
+
+      // override the invocation timeout
+      this.invocation.timeout = this.durablePromise.timeout;
     }
 
     return this.invocation.future;
@@ -219,6 +224,9 @@ export class DeferredExecution<T> extends Execution<T> {
         },
       );
 
+      // override the invocation creation time
+      this.invocation.createdOn = this.durablePromise.createdOn;
+
       // override the invocation timeout
       this.invocation.timeout = this.durablePromise.timeout;
     } catch (e) {
@@ -274,15 +282,20 @@ export class GeneratorExecution<T> extends Execution<T> {
             },
           ));
 
-        // override the invocation timeout
-        this.invocation.timeout = this.durablePromise.timeout;
-
         // resolve/reject the invocation if already completed
         if (this.durablePromise.resolved) {
           this.invocation.resolve(this.durablePromise.value());
         } else if (this.durablePromise.rejected || this.durablePromise.canceled || this.durablePromise.timedout) {
           this.invocation.reject(this.durablePromise.error());
         }
+      }
+
+      if (this.durablePromise) {
+        // override the invocation creation time
+        this.invocation.createdOn = this.durablePromise.createdOn;
+
+        // override the invocation timeout
+        this.invocation.timeout = this.durablePromise.timeout;
       }
     } catch (e) {
       // if an error occurs, kill the execution

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -16,7 +16,7 @@ export class Invocation<T> {
 
   killed: boolean = false;
 
-  createdAt: number = Date.now();
+  createdOn: number = Date.now();
   counter: number = 0;
   attempt: number = 0;
 
@@ -68,7 +68,7 @@ export class Invocation<T> {
     // the timeout is the minimum of:
     // - the current time plus the user provided relative time
     // - the parent timeout
-    this.timeout = Math.min(this.createdAt + this.opts.timeout, this.parent?.timeout ?? Infinity);
+    this.timeout = Math.min(this.createdOn + this.opts.timeout, this.parent?.timeout ?? Infinity);
   }
 
   addChild(child: Invocation<any>) {

--- a/lib/core/promises/promises.ts
+++ b/lib/core/promises/promises.ts
@@ -51,6 +51,10 @@ export class DurablePromise<T> {
     return this.promise.idempotencyKeyForComplete;
   }
 
+  get createdOn() {
+    return this.promise.createdOn;
+  }
+
   get timeout() {
     return this.promise.timeout;
   }

--- a/lib/generator.ts
+++ b/lib/generator.ts
@@ -205,6 +205,13 @@ export class Context {
   }
 
   /**
+   * The time the invocation was created. Will use the durable promise creation time if available.
+   */
+  get createdOn() {
+    return this.invocation.createdOn;
+  }
+
+  /**
    * Uniquely identifies the function invocation.
    */
   get id() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@resonatehq/sdk",
-    "version": "0.3.7",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@resonatehq/sdk",
-            "version": "0.3.7",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "cron-parser": "^4.9.0"


### PR DESCRIPTION
This time indicates the time that the durable promise was created, if an execution has opted out of a durable promise the time that the invocation was created will be used instead.