### PR TITLE
Store the retry policy with the DurablePromise.

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -448,6 +448,7 @@ class Scheduler {
     const param = {
       func: name,
       version: opts.version,
+      retryPolicy: opts.retry,
       args,
     };
 

--- a/lib/core/encoders/json.ts
+++ b/lib/core/encoders/json.ts
@@ -10,6 +10,14 @@ export class JSONEncoder implements IEncoder<unknown, string | undefined> {
     }
 
     return JSON.stringify(data, (_, value) => {
+      if (value === Infinity) {
+        return "Infinity";
+      }
+
+      if (value === -Infinity) {
+        return "-Infinity";
+      }
+
       if (value instanceof AggregateError) {
         return {
           __type: "aggregate_error",
@@ -53,6 +61,14 @@ export class JSONEncoder implements IEncoder<unknown, string | undefined> {
     }
 
     return JSON.parse(data, (_, value) => {
+      if (value === "Infinity") {
+        return Infinity;
+      }
+
+      if (value === "-Infinity") {
+        return Infinity;
+      }
+
       if (value?.__type === "aggregate_error") {
         return Object.assign(new AggregateError(value.errors, value.message), value);
       }

--- a/lib/core/invocation.ts
+++ b/lib/core/invocation.ts
@@ -71,7 +71,6 @@ export class Invocation<T> {
     // - the current time plus the user provided relative time
     // - the parent timeout
     this.timeout = Math.min(this.createdOn + this.opts.timeout, this.parent?.timeout ?? Infinity);
-
     this.retryPolicy = this.opts.retry;
   }
 

--- a/test/resonate.test.ts
+++ b/test/resonate.test.ts
@@ -183,8 +183,8 @@ describe("Resonate", () => {
         expect(() => schedule(resonate, "baz", "", () => {})).toThrow("Function baz version 1 already registered");
 
         register(resonate, "qux", () => {});
-        expect(() => resonate.schedule("qux", "x", "qux")).rejects.toThrow();
-        expect(() => resonate.schedule("qux", "* * * * * * *", "qux")).rejects.toThrow();
+        expect(resonate.schedule("qux", "x", "qux")).rejects.toThrow();
+        expect(resonate.schedule("qux", "* * * * * * *", "qux")).rejects.toThrow();
 
         // delete the schedules in order to stop the local
         // store interval that creates promises


### PR DESCRIPTION
With this change we start storing the retry policy with the DurablePromise.
This enables the recovery path to use the retry policy that was set when executing the function originally instead of the default retry policy.