### PR TITLE
Removes "default" options from the invocation

### DIFF
--- a/lib/core/execution.ts
+++ b/lib/core/execution.ts
@@ -91,23 +91,21 @@ export class OrdinaryExecution<T> extends Execution<T> {
   }
 
   protected async fork() {
-    if (this.invocation.opts.durable) {
+    if (this.invocation.opts.durable && !this.durablePromise) {
       // if durable, create a durable promise
       try {
-        this.durablePromise =
-          this.durablePromise ??
-          (await DurablePromise.create<T>(
-            this.resonate.store.promises,
-            this.invocation.opts.encoder,
-            this.invocation.id,
-            this.invocation.timeout,
-            {
-              idempotencyKey: this.invocation.idempotencyKey,
-              headers: this.invocation.headers,
-              param: this.invocation.param,
-              tags: this.invocation.opts.tags,
-            },
-          ));
+        this.durablePromise = await DurablePromise.create<T>(
+          this.resonate.store.promises,
+          this.invocation.opts.encoder,
+          this.invocation.id,
+          this.invocation.timeout,
+          {
+            idempotencyKey: this.invocation.idempotencyKey,
+            headers: this.invocation.headers,
+            param: this.invocation.param,
+            tags: this.invocation.opts.tags,
+          },
+        );
       } catch (e) {
         // if an error occurs, kill the execution
         this.kill(e);
@@ -265,22 +263,20 @@ export class GeneratorExecution<T> extends Execution<T> {
 
   async create() {
     try {
-      if (this.invocation.opts.durable) {
+      if (this.invocation.opts.durable && !this.durablePromise) {
         // create a durable promise
-        this.durablePromise =
-          this.durablePromise ??
-          (await DurablePromise.create<T>(
-            this.resonate.store.promises,
-            this.invocation.opts.encoder,
-            this.invocation.id,
-            this.invocation.timeout,
-            {
-              idempotencyKey: this.invocation.idempotencyKey,
-              headers: this.invocation.headers,
-              param: this.invocation.param,
-              tags: this.invocation.opts.tags,
-            },
-          ));
+        this.durablePromise = await DurablePromise.create<T>(
+          this.resonate.store.promises,
+          this.invocation.opts.encoder,
+          this.invocation.id,
+          this.invocation.timeout,
+          {
+            idempotencyKey: this.invocation.idempotencyKey,
+            headers: this.invocation.headers,
+            param: this.invocation.param,
+            tags: this.invocation.opts.tags,
+          },
+        );
 
         // resolve/reject the invocation if already completed
         if (this.durablePromise.resolved) {

--- a/lib/core/options.ts
+++ b/lib/core/options.ts
@@ -83,9 +83,10 @@ export type Options = {
   durable: boolean;
 
   /**
-   * A unique id for this execution, defaults to a random id.
+   * A function that calculates the id for this execution
+   * defaults to a random funciton.
    */
-  eid: string | ((id: string) => string);
+  eidFn: (id: string) => string;
 
   /**
    * Overrides the default encoder.
@@ -93,9 +94,10 @@ export type Options = {
   encoder: IEncoder<unknown, string | undefined>;
 
   /**
-   * Overrides the default idempotency key.
+   * Overrides the default funciton to calculate the idempotency key.
+   * defaults to a variation fnv-1a the hash funciton.
    */
-  idempotencyKey: string | ((id: string) => string);
+  idempotencyKeyFn: (id: string) => string;
 
   /**
    * Acquire a lock for the execution.

--- a/lib/core/promises/promises.ts
+++ b/lib/core/promises/promises.ts
@@ -202,19 +202,16 @@ export class DurablePromise<T> {
     timeout: number,
     opts: Partial<CreateOptions> = {},
   ) {
-    return new DurablePromise<T>(
-      store,
-      encoder,
-      await store.create(
-        id,
-        opts.idempotencyKey,
-        opts.strict ?? false,
-        opts.headers,
-        encoder.encode(opts.param),
-        timeout,
-        opts.tags,
-      ),
+    const storedPromise = await store.create(
+      id,
+      opts.idempotencyKey,
+      opts.strict ?? false,
+      opts.headers,
+      encoder.encode(opts.param),
+      timeout,
+      opts.tags,
     );
+    return new DurablePromise<T>(store, encoder, storedPromise);
   }
 
   /**

--- a/lib/core/utils.ts
+++ b/lib/core/utils.ts
@@ -1,3 +1,5 @@
+import { Options, isOptions } from "./options";
+
 export function randomId(): string {
   return Math.floor(Math.random() * Number.MAX_SAFE_INTEGER).toString(16);
 }
@@ -12,4 +14,11 @@ export function hash(s: string): string {
   const hashString = (Math.abs(h) >>> 0).toString(16); // Convert to unsigned int and then to hexadecimal
   const maxLength = 8;
   return "0".repeat(Math.max(0, maxLength - hashString.length)) + hashString;
+}
+
+export function split(argsWithOpts: any[]): { args: any[]; opts: Partial<Options> } {
+  const possibleOpts = argsWithOpts.at(-1);
+  return isOptions(possibleOpts)
+    ? { args: argsWithOpts.slice(0, -1), opts: possibleOpts }
+    : { args: argsWithOpts, opts: {} };
 }

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -43,9 +43,9 @@ describe("Options", () => {
 
   const overrides = {
     durable: false,
-    eid: "eid",
+    eidFn: () => "eid",
     encoder: new Base64Encoder(),
-    idempotencyKey: "idempotencyKey",
+    idempotencyKeyFn: (_: string) => "idempotencyKey",
     lock: false,
     poll: 2000,
     retry: retry.linear(),
@@ -79,11 +79,12 @@ describe("Options", () => {
           resonate.options({ version: 1 }),
         );
 
+        // Most options defaults are set when created a resonate instance
         for (const opts of [top, middle, bottom]) {
           expect(opts.durable).toBe(false);
-          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.eidFn).toBe(utils.randomId);
           expect(opts.encoder).toBe(resonateOpts.encoder);
-          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.idempotencyKeyFn).toBe(utils.hash);
           expect(opts.poll).toBe(resonateOpts.poll);
           expect(opts.retry).toBe(resonateOpts.retry);
           expect(opts.timeout).toBe(resonateOpts.timeout);
@@ -104,9 +105,9 @@ describe("Options", () => {
 
         for (const opts of [top, middle, bottom]) {
           expect(opts.durable).toBe(overrides.durable);
-          expect(opts.eid).toBe(overrides.eid);
+          expect(opts.eidFn).toBe(overrides.eidFn);
           expect(opts.encoder).toBe(overrides.encoder);
-          expect(opts.idempotencyKey).toBe(overrides.idempotencyKey);
+          expect(opts.idempotencyKeyFn).toBe(overrides.idempotencyKeyFn);
           expect(opts.lock).toBe(overrides.lock);
           expect(opts.poll).toBe(overrides.poll);
           expect(opts.retry).toBe(overrides.retry);
@@ -131,9 +132,9 @@ describe("Options", () => {
 
         // top level options
         expect(top.durable).toBe(false);
-        expect(top.eid).toBe(utils.randomId);
+        expect(top.eidFn).toBe(overrides.eidFn);
         expect(top.encoder).toBe(resonateOpts.encoder);
-        expect(top.idempotencyKey).toBe(overrides.idempotencyKey);
+        expect(top.idempotencyKeyFn).toBe(overrides.idempotencyKeyFn);
         expect(top.lock).toBe(true);
         expect(top.poll).toBe(resonateOpts.poll);
         expect(top.retry).toBe(resonateOpts.retry);
@@ -144,9 +145,9 @@ describe("Options", () => {
         // bottom level options
         for (const opts of bottom) {
           expect(opts.durable).toBe(false);
-          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.eidFn).toBe(utils.randomId);
           expect(opts.encoder).toBe(resonateOpts.encoder);
-          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.idempotencyKeyFn).toBe(utils.hash);
           expect(opts.lock).toBe(false);
           expect(opts.poll).toBe(resonateOpts.poll);
           expect(opts.retry).toBe(resonateOpts.retry);
@@ -166,27 +167,29 @@ describe("Options", () => {
 
         // middle options (overriden)
         expect(middle.durable).toBe(overrides.durable);
-        expect(middle.eid).toBe(overrides.eid);
+        expect(middle.eidFn).toBe(overrides.eidFn);
         expect(middle.encoder).toBe(overrides.encoder);
-        expect(middle.idempotencyKey).toBe(overrides.idempotencyKey);
+        expect(middle.idempotencyKeyFn).toBe(overrides.idempotencyKeyFn);
         expect(middle.lock).toBe(overrides.lock);
         expect(middle.poll).toBe(overrides.poll);
         expect(middle.retry).toBe(overrides.retry);
         expect(middle.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags });
         expect(middle.timeout).toBe(overrides.timeout);
-        expect(middle.version).toBe(1);
 
         // top and bottom options
         for (const opts of [top, bottom]) {
           expect(opts.durable).toBe(false);
-          expect(opts.eid).toBe(utils.randomId);
+          expect(opts.eidFn).toBe(utils.randomId);
           expect(opts.encoder).toBe(resonateOpts.encoder);
-          expect(opts.idempotencyKey).toBe(utils.hash);
+          expect(opts.idempotencyKeyFn).toBe(utils.hash);
           expect(opts.poll).toBe(resonateOpts.poll);
           expect(opts.retry).toBe(resonateOpts.retry);
           expect(opts.timeout).toBe(resonateOpts.timeout);
-          expect(opts.version).toBe(1);
         }
+
+        expect(top.version).toBe(1);
+        expect(middle.version).toBeDefined();
+        expect(bottom.version).toBeDefined();
 
         expect(top.lock).toBe(true);
         expect(bottom.lock).toBe(false);


### PR DESCRIPTION
Default options in the invocation were in reality
the registered options from the top level function call. This commit changes the code to express that more clearly and removes the split functions that were a source of confusion.