### PR TITLE
Add initial support for Function Call types

### DIFF
--- a/lib/async.ts
+++ b/lib/async.ts
@@ -1,3 +1,4 @@
+import { Func, Params, Return } from "./core/calls";
 import { Execution, OrdinaryExecution, DeferredExecution } from "./core/execution";
 import { ResonatePromise } from "./core/future";
 import { Invocation } from "./core/invocation";
@@ -11,12 +12,6 @@ import { ResonateBase } from "./resonate";
 /////////////////////////////////////////////////////////////////////
 // Types
 /////////////////////////////////////////////////////////////////////
-
-export type Func = (ctx: Context, ...args: any[]) => any;
-
-export type Params<F> = F extends (ctx: any, ...args: infer P) => any ? P : never;
-
-export type Return<F> = F extends (...args: any[]) => infer T ? Awaited<T> : never;
 
 /////////////////////////////////////////////////////////////////////
 // Resonate

--- a/lib/async.ts
+++ b/lib/async.ts
@@ -206,12 +206,12 @@ export class Context {
    *
    * @description
    * This function takes a Remote Function Call (RFC) configuration and executes the specified function
-   * remotely with the provided options. It returns a ResonatePromise that resolves .
+   * remotely with the provided options.
    */
   run<T>(rfc: RFC): ResonatePromise<T>;
 
   /**
-   * Invoke a remote function.
+   * Invoke a remote function without arguments.
    *
    * @template T The return type of the remote function.
    * @param func The id of the remote function.

--- a/lib/core/calls.ts
+++ b/lib/core/calls.ts
@@ -1,0 +1,30 @@
+import { Context } from "..";
+import { Options } from "./options";
+
+// The type of a resonate function
+export type Func = (ctx: Context, ...args: any[]) => any;
+
+// The args of a resonate function excluding the context argument
+export type Params<F> = F extends (ctx: any, ...args: infer P) => any ? P : never;
+
+// The return type of a resonate function
+export type Return<F> = F extends (...args: any[]) => infer T ? Awaited<T> : never;
+
+// A top level functio call, to be used in the with `resonate.run`
+export type TFC = {
+  // Fuction Name of the function to be called, has to be previously registered
+  funcName: string;
+  // Given id for this execution, ids have to be distinct between top level calls
+  id: string;
+  // args to be passed to the specified func.
+  args?: any[];
+  // opts to override the registered Options. Only the subset of options stored
+  // with the DurablePromise can be overriden that way we can have the same set
+  // of options when running in the recovery path.
+  optsOverrides?: Partial<
+    Pick<Options, "durable" | "eidFn" | "idempotencyKeyFn" | "retry" | "tags" | "timeout" | "version">
+  >;
+};
+
+// Remote function call
+export type RFC = never;

--- a/lib/core/calls.ts
+++ b/lib/core/calls.ts
@@ -27,4 +27,26 @@ export type TFC = {
 };
 
 // Remote function call
-export type RFC = never;
+export type RFC = {
+  funcName: string;
+  args?: any;
+  opts?: Partial<Options>;
+};
+
+// Remote function call
+export type LFC<F extends Func> = {
+  func: F;
+  args?: any[];
+  opts?: Partial<Options>;
+};
+
+// Type guard for RFC
+export function isRFC(obj: any): obj is RFC {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    typeof obj.funcName === "string" &&
+    (obj.args === undefined || typeof obj.args === "object") &&
+    (obj.opts === undefined || (typeof obj.opts === "object" && obj.opts !== null))
+  );
+}

--- a/lib/core/calls.ts
+++ b/lib/core/calls.ts
@@ -10,7 +10,7 @@ export type Params<F> = F extends (ctx: any, ...args: infer P) => any ? P : neve
 // The return type of a resonate function
 export type Return<F> = F extends (...args: any[]) => infer T ? Awaited<T> : never;
 
-// A top level functio call, to be used in the with `resonate.run`
+// A top level function call, to be used in the with `resonate.run`
 export type TFC = {
   // Fuction Name of the function to be called, has to be previously registered
   funcName: string;

--- a/lib/core/utils.ts
+++ b/lib/core/utils.ts
@@ -22,3 +22,33 @@ export function split(argsWithOpts: any[]): { args: any[]; opts: Partial<Options
     ? { args: argsWithOpts.slice(0, -1), opts: possibleOpts }
     : { args: argsWithOpts, opts: {} };
 }
+
+/**
+ * Merges two objects, preferring values from the first object when both are defined.
+ * If a property is undefined in the first object, the value from the second object is used.
+ *
+ * @template T - Type of the first object
+ * @template U - Type of the second object
+ * @param {T} obj1 - The first object to merge
+ * @param {U} obj2 - The second object to merge
+ * @returns {T & U} A new object containing all properties from both input objects
+ *
+ * @example
+ * const obj1 = { a: 1, b: undefined };
+ * const obj2 = { b: 2, c: 3 };
+ * const result = mergeObjects(obj1, obj2);
+ * // result is { a: 1, b: 2, c: 3 }
+ *
+ * @remarks
+ * - Properties from obj1 take precedence over obj2 when both are defined.
+ * - The function creates a new object and does not modify the input objects.
+ * - Nested objects and arrays are not deeply merged, only their references are copied.
+ */
+export function mergeObjects<T extends object, U extends object>(obj1: T, obj2: U): T & U {
+  return Object.entries({ ...obj1, ...obj2 }).reduce((acc, [key, value]) => {
+    acc[key as keyof (T & U)] = (
+      obj1[key as keyof T] !== undefined ? obj1[key as keyof T] : obj2[key as keyof U]
+    ) as any;
+    return acc;
+  }, {} as any);
+}

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -63,6 +63,11 @@ describe("Functions: async", () => {
       await resonate.run("run", "run.c", deferredSuccess),
       await resonate.run("success", "run.d"),
       await resonate.run("successAsync", "run.e"),
+      await resonate.run({ funcName: "run", id: "run.a", args: [ordinarySuccess] }),
+      await resonate.run({ funcName: "run", id: "run.b", args: [ordinarySuccessAsync] }),
+      await resonate.run({ funcName: "run", id: "run.c", args: [deferredSuccess] }),
+      await resonate.run({ funcName: "success", id: "run.d" }),
+      await resonate.run({ funcName: "successAsync", id: "run.e" }),
     ];
 
     expect(results.every((r) => r === "foo")).toBe(true);
@@ -91,6 +96,11 @@ describe("Functions: async", () => {
       () => resonate.run("run", "run.c", deferredFailure),
       () => resonate.run("failure", "run.d"),
       () => resonate.run("failureAsync", "run.e"),
+      () => resonate.run({ funcName: "run", id: "run.a", args: [ordinaryFailure] }),
+      () => resonate.run({ funcName: "run", id: "run.b", args: [ordinaryFailureAsync] }),
+      () => resonate.run({ funcName: "run", id: "run.c", args: [deferredFailure] }),
+      () => resonate.run({ funcName: "failure", id: "run.d" }),
+      () => resonate.run({ funcName: "failureAsync", id: "run.e" }),
     ];
 
     for (const f of functions) {

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -10,6 +10,10 @@ describe("Functions: async", () => {
     return await ctx.run(func);
   }
 
+  async function runFC(ctx: Context, func: any) {
+    return await ctx.run({ func: func });
+  }
+
   function ordinarySuccess() {
     return "foo";
   }
@@ -30,8 +34,16 @@ describe("Functions: async", () => {
     return await ctx.run("success", ctx.options({ poll: 0 }));
   }
 
+  async function deferredSuccessRFC(ctx: Context) {
+    return await ctx.run({ funcName: "success", opts: ctx.options({ poll: 0 }) });
+  }
+
   async function deferredFailure(ctx: Context) {
     return await ctx.run("failure", ctx.options({ poll: 0 }));
+  }
+
+  async function deferredFailureRFC(ctx: Context) {
+    return await ctx.run({ funcName: "failure", opts: ctx.options({ poll: 0 }) });
   }
 
   test("success", async () => {
@@ -46,6 +58,7 @@ describe("Functions: async", () => {
     });
 
     resonate.register("run", run);
+    resonate.register("runFC", runFC);
     resonate.register("success", ordinarySuccess);
     resonate.register("successAsync", ordinarySuccessAsync);
 
@@ -68,6 +81,7 @@ describe("Functions: async", () => {
       await resonate.run({ funcName: "run", id: "run.c", args: [deferredSuccess] }),
       await resonate.run({ funcName: "success", id: "run.d" }),
       await resonate.run({ funcName: "successAsync", id: "run.e" }),
+      await resonate.run({ funcName: "runFC", id: "run.f", args: [deferredSuccessRFC] }),
     ];
 
     expect(results.every((r) => r === "foo")).toBe(true);
@@ -80,6 +94,7 @@ describe("Functions: async", () => {
     });
 
     resonate.register("run", run);
+    resonate.register("runFC", runFC);
     resonate.register("failure", ordinaryFailure);
     resonate.register("failureAsync", ordinaryFailureAsync);
 
@@ -101,10 +116,48 @@ describe("Functions: async", () => {
       () => resonate.run({ funcName: "run", id: "run.c", args: [deferredFailure] }),
       () => resonate.run({ funcName: "failure", id: "run.d" }),
       () => resonate.run({ funcName: "failureAsync", id: "run.e" }),
+      () => resonate.run({ funcName: "runFC", id: "run.f", args: [deferredFailureRFC] }),
     ];
 
     for (const f of functions) {
       await expect(f()).rejects.toThrow("foo");
     }
+  });
+  test("FC and non FC apis produce same result", async () => {
+    const resonate = new Resonate({
+      timeout: 1000,
+      retry: retry.linear(0, 3),
+    });
+
+    resonate.register("runFC", async (ctx: Context, arg1: string, arg2: string) => {
+      const a = await ctx.run({
+        func: (ctx: Context, arg: string) => {
+          return arg;
+        },
+        args: [arg1],
+      });
+      const b = await ctx.run({
+        func: (ctx: Context, arg: string) => {
+          return arg;
+        },
+        args: [arg2],
+      });
+      return a + b;
+    });
+
+    resonate.register("run", async (ctx: Context, arg1: string, arg2: string) => {
+      const a = await ctx.run((ctx: Context, arg: string) => {
+        return arg;
+      }, arg1);
+      const b = await ctx.run((ctx: Context, arg: string) => {
+        return arg;
+      }, arg2);
+      return a + b;
+    });
+
+    const fcResult = await resonate.run({ funcName: "runFC", id: "run.a", args: ["foo", "bar"] });
+    const regularResult = await resonate.run("run", "run.b", "foo", "bar");
+
+    expect(fcResult).toBe(regularResult);
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -137,7 +137,7 @@ describe("Options", () => {
         expect(top.idempotencyKeyFn).toBe(overrides.idempotencyKeyFn);
         expect(top.lock).toBe(true);
         expect(top.poll).toBe(resonateOpts.poll);
-        expect(top.retry).toBe(resonateOpts.retry);
+        expect(top.retry).toBe(overrides.retry);
         expect(top.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags, "resonate:invocation": "true" });
         expect(top.timeout).toBe(overrides.timeout);
         expect(top.version).toBe(overrides.version);

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect, jest } from "@jest/globals";
+import { mergeObjects } from "../lib/core/utils";
+
+jest.setTimeout(1000);
+
+describe("mergeObjects", () => {
+  test("merges two objects with non-overlapping keys", () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { c: 3, d: 4 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 3, d: 4 });
+  });
+
+  test("prefers values from obj1 when keys overlap and neither is undefined", () => {
+    const obj1 = { a: 1, b: 2 };
+    const obj2 = { b: 3, c: 4 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 4 });
+  });
+
+  test("uses obj2 value when obj1 value is undefined", () => {
+    const obj1 = { a: 1, b: undefined as number | undefined };
+    const obj2 = { b: 2, c: 3 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  test("handles nested objects", () => {
+    const obj1 = { a: { x: 1 }, b: 2 };
+    const obj2 = { a: { y: 2 }, c: 3 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: { x: 1 }, b: 2, c: 3 });
+  });
+
+  test("handles arrays", () => {
+    const obj1 = { a: [1, 2], b: 2 };
+    const obj2 = { a: [3, 4], c: 3 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: [1, 2], b: 2, c: 3 });
+  });
+
+  test("handles empty objects", () => {
+    const obj1 = {};
+    const obj2 = { a: 1 };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: 1 });
+  });
+
+  test("handles objects with null values", () => {
+    const obj1 = { a: null, b: 2 };
+    const obj2 = { a: 1, c: null };
+    const result = mergeObjects(obj1, obj2);
+    expect(result).toEqual({ a: null, b: 2, c: null });
+  });
+});


### PR DESCRIPTION
This PR implements the first part of this proposal #120. It focuses mostly in bringing the FC concepts to the api surface, future PR will bring this concept deeper into the architecture.