### PR TITLE
Make locks for the top level function opt-in

### DIFF
--- a/lib/resonate.ts
+++ b/lib/resonate.ts
@@ -195,7 +195,8 @@ export class Resonate {
    */
   async start(delay: number = 5000) {
     clearInterval(this.#interval);
-    this.#_start();
+    // await the first run of the recovery path to avoid races with the normal flow of the program
+    await this.#_start();
     this.#interval = setInterval(this.#_start.bind(this), delay);
   }
 
@@ -293,8 +294,8 @@ export class Resonate {
     // resonate:invocation tag to identify a top level invocation
     opts.tags = { ...registeredOpts.tags, ...tags, "resonate:invocation": "true" };
 
-    // lock on top level is true by default
-    opts.shouldLock = opts.shouldLock ?? true;
+    // locking is false by default
+    opts.shouldLock = opts.shouldLock ?? false;
 
     const param = {
       func: name,

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -67,7 +67,7 @@ describe("Options", () => {
       expect(opts.version).toBe(1);
     }
 
-    expect(top.shouldLock).toBe(true);
+    expect(top.shouldLock).toBe(false);
     expect(middle.shouldLock).toBe(false);
     expect(bottom.shouldLock).toBe(false);
 
@@ -107,7 +107,7 @@ describe("Options", () => {
     expect(top.eidFn).toBe(overrides.eidFn);
     expect(top.encoder).toBe(resonateOpts.encoder);
     expect(top.idempotencyKeyFn).toBe(overrides.idempotencyKeyFn);
-    expect(top.shouldLock).toBe(true);
+    expect(top.shouldLock).toBe(false);
     expect(top.pollFrequency).toBe(resonateOpts.pollFrequency);
     expect(top.retryPolicy).toBe(overrides.retryPolicy);
     expect(top.tags).toEqual({ ...resonateOpts.tags, ...overrides.tags, "resonate:invocation": "true" });
@@ -157,14 +157,12 @@ describe("Options", () => {
       expect(opts.pollFrequency).toBe(resonateOpts.pollFrequency);
       expect(opts.retryPolicy).toBe(resonateOpts.retryPolicy);
       expect(opts.timeout).toBe(resonateOpts.timeout);
+      expect(opts.shouldLock).toBe(false);
     }
 
     expect(top.version).toBe(1);
     expect(middle.version).toBeDefined();
     expect(bottom.version).toBeDefined();
-
-    expect(top.shouldLock).toBe(true);
-    expect(bottom.shouldLock).toBe(false);
 
     expect(top.tags).toEqual({ ...resonateOpts.tags, "resonate:invocation": "true" });
     expect(bottom.tags).toEqual(resonateOpts.tags);


### PR DESCRIPTION
This should improve the default experience during recovery,
and allows more advance use cases to use locks when necessary.