### PR TITLE
Add handleCompletePromise helper function

### DIFF
--- a/lib/core/promises/types.ts
+++ b/lib/core/promises/types.ts
@@ -1,3 +1,7 @@
+import assert from "assert";
+import { IEncoder } from "../encoder";
+import { ErrorCodes, ResonateError } from "../errors";
+
 export type DurablePromiseRecord = {
   state: "PENDING" | "RESOLVED" | "REJECTED" | "REJECTED_CANCELED" | "REJECTED_TIMEDOUT";
   id: string;
@@ -50,4 +54,35 @@ export function isTimedoutPromise(p: DurablePromiseRecord): boolean {
 
 export function isCompletedPromise(p: DurablePromiseRecord): boolean {
   return ["RESOLVED", "REJECTED", "REJECTED_CANCELED", "REJECTED_TIMEDOUT"].includes(p.state);
+}
+
+/**
+ * Handles a completed durable promise and returns its result.
+ *
+ * @param p - The DurablePromiseRecord to handle.
+ * @param encoder - An IEncoder instance used to decode the promise's data.
+ * @returns The decoded result of the promise if resolved, or null if pending.
+ * @throws {ResonateError} If the promise was rejected, canceled, or timed out.
+ *
+ * @remarks
+ * Users must handle the null return case, which could indicate either:
+ * 1. The promise is still pending, or
+ * 2. The promise completed with a null value.
+ * It's important to distinguish between these cases in the calling code if necessary.
+ */
+export function handleCompletedPromise<R>(p: DurablePromiseRecord, encoder: IEncoder<unknown, string | undefined>): R {
+  assert(p.state !== "PENDING", "Promise was pending when trying to handle its completion");
+  switch (p.state) {
+    case "RESOLVED":
+      return encoder.decode(p.value.data) as R;
+    case "REJECTED":
+      throw encoder.decode(p.value.data);
+    case "REJECTED_CANCELED":
+      throw new ResonateError("Resonate function canceled", ErrorCodes.CANCELED, encoder.decode(p.value.data));
+    case "REJECTED_TIMEDOUT":
+      throw new ResonateError(
+        `Resonate function timedout at ${new Date(p.timeout).toISOString()}`,
+        ErrorCodes.TIMEDOUT,
+      );
+  }
 }

--- a/test/userResources.test.ts
+++ b/test/userResources.test.ts
@@ -10,13 +10,12 @@ describe("User Defined Resources", () => {
 
     resonate.register("resource", async (ctx: Context, resourceVal: unknown) => {
       ctx.setResource("mock", resourceVal);
-      return ctx.getResource("mock");
+      const resource = ctx.getResource("mock");
+      expect(resource).toBe(resourceVal);
     });
 
     const resourceVal = {};
-    const handle = await resonate.invokeLocal<void>("resource", "resource.0", resourceVal);
-
-    await expect(handle.result()).resolves.toBe(resourceVal);
+    await resonate.invokeLocal<void>("resource", "resource.0", resourceVal);
   });
 
   test("Set a resource and get it deep in the context stack", async () => {


### PR DESCRIPTION
We had some code repetition around handling a completed durable promise. The repetition was fine, how ever this pattern will come to callbacks and tasks and we will have it in atleast 4 more places, having to write that code that many times is error prone and verbose.

This change also fixes a bug made evident by this helper funciton where we were returning the value computed by the function directly instead of the value stored in the completed durable promise.