### PR TITLE
Implement resonate run, rpc, beginRun, beginRpc

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,87 +1,76 @@
-import type { Func, Params, RemoteOpts, Return } from "./types";
+import { type Func, type Options, type ParamsWithOptions, RESONATE_OPTIONS, type Return } from "./types";
 import * as util from "./util";
 
-const defaultRemoteOpts: RemoteOpts = {
-  target: "default",
-  timeout: Number.MAX_SAFE_INTEGER,
-};
+export type Yieldable = LFI<any> | LFC<any> | RFI<any> | RFC<any> | Future<any>;
 
-export type Yieldable = InvokeLocal<any> | InvokeRemote<any> | Future<any> | CallLocal<any> | CallRemote<any>;
-
-export class InvokeLocal<T> implements Iterable<InvokeLocal<T>> {
+export class LFI<T> implements Iterable<LFI<T>> {
   public func: Func;
   public args: any[];
+  public opts: Options;
 
-  constructor(func: Func, args: any[]) {
+  constructor(func: Func, args: any[], opts: Options) {
     this.func = func;
     this.args = args;
+    this.opts = opts;
   }
 
-  *[Symbol.iterator](): Generator<InvokeLocal<T>, Future<T>, any> {
+  *[Symbol.iterator](): Generator<LFI<T>, Future<T>, any> {
     const v = yield this;
-    util.assert(v instanceof Future, "expected Future");
+    util.assert(v instanceof Future, "expected future");
     return v as Future<T>;
   }
 }
 
-export class InvokeRemote<T> implements Iterable<InvokeRemote<T>> {
-  public func: string;
-  public args: any[];
-  public opts: RemoteOpts;
-
-  constructor(func: string, args: any[]) {
-    this.func = func;
-    this.args = args;
-    this.opts = { ...defaultRemoteOpts };
-  }
-
-  options(opts: Partial<RemoteOpts>): InvokeRemote<T> {
-    this.opts = { ...this.opts, ...opts };
-    return this;
-  }
-
-  *[Symbol.iterator](): Generator<InvokeRemote<T>, Future<T>, any> {
-    const v = yield this;
-    util.assert(v instanceof Future, "expected Future");
-    return v as Future<T>;
-  }
-}
-
-export class CallLocal<T> implements Iterable<CallLocal<T>> {
+export class LFC<T> implements Iterable<LFC<T>> {
   public func: Func;
   public args: any[];
+  public opts: Options;
 
-  constructor(func: Func, args: any[]) {
+  constructor(func: Func, args: any[], opts: Options) {
     this.func = func;
     this.args = args;
+    this.opts = opts;
   }
 
-  *[Symbol.iterator](): Generator<CallLocal<T>, T, any> {
+  *[Symbol.iterator](): Generator<LFC<T>, T, any> {
     const v = yield this;
-    util.assert(!(v instanceof Future), "expected a value other than Future");
+    util.assert(!(v instanceof Future), "expected value");
     return v as T;
   }
 }
 
-export class CallRemote<T> implements Iterable<CallRemote<T>> {
+export class RFI<T> implements Iterable<RFI<T>> {
   public func: string;
   public args: any[];
-  public opts: RemoteOpts;
+  public opts: Options;
 
-  constructor(func: string, args: any[]) {
+  constructor(func: string, args: any[], opts: Options) {
     this.func = func;
     this.args = args;
-    this.opts = { ...defaultRemoteOpts };
+    this.opts = opts;
   }
 
-  options(opts: Partial<RemoteOpts>): CallRemote<T> {
-    this.opts = { ...this.opts, ...opts };
-    return this;
-  }
-
-  *[Symbol.iterator](): Generator<CallRemote<T>, T, any> {
+  *[Symbol.iterator](): Generator<RFI<T>, Future<T>, any> {
     const v = yield this;
-    util.assert(!(v instanceof Future), "expected a value other than Future");
+    util.assert(v instanceof Future, "expected future");
+    return v as Future<T>;
+  }
+}
+
+export class RFC<T> implements Iterable<RFC<T>> {
+  public func: string;
+  public args: any[];
+  public opts: Options;
+
+  constructor(func: string, args: any[], opts: Options) {
+    this.func = func;
+    this.args = args;
+    this.opts = opts;
+  }
+
+  *[Symbol.iterator](): Generator<RFC<T>, T, any> {
+    const v = yield this;
+    util.assert(!(v instanceof Future), "expected value");
     return v as T;
   }
 }
@@ -114,23 +103,44 @@ export class Future<T> implements Iterable<Future<T>> {
 }
 
 export class Context {
-  // TODO(avillega): Allow user to define other opts
-  beginRun<F extends Func>(func: F, ...args: Params<F>): InvokeLocal<Return<F>> {
-    return new InvokeLocal<Return<F>>(func, args);
+  run = this.lfc;
+  rpc = this.rfc;
+  beginRun = this.lfi;
+  beginRpc = this.rfi;
+
+  lfi<F extends Func>(func: F, ...args: ParamsWithOptions<F>): LFI<Return<F>> {
+    return new LFI(func, ...util.splitArgsAndOpts(args, this.options()));
   }
 
-  // TODO(avillega): Allow user to define target, and opts
-  beginRpc<R>(func: string, ...args: any[]): InvokeRemote<R> {
-    return new InvokeRemote<R>(func, args);
+  lfc<F extends Func>(func: F, ...args: ParamsWithOptions<F>): LFC<Return<F>> {
+    return new LFC(func, ...util.splitArgsAndOpts(args, this.options()));
   }
 
-  // TODO(avillega): Allow user to define other opts
-  run<F extends Func>(func: F, ...args: Params<F>): CallLocal<Return<F>> {
-    return new CallLocal<Return<F>>(func, args);
+  rfi<F extends Func>(func: F, ...args: ParamsWithOptions<F>): RFI<Return<F>>;
+  rfi<T>(func: string, ...args: any[]): RFI<T>;
+  rfi(func: Func | string, ...args: any[]): RFI<any> {
+    if (typeof func === "function") {
+      throw new Error("not implemented");
+    }
+    return new RFI(func, ...util.splitArgsAndOpts(args, this.options()));
   }
 
-  // TODO(avillega): Allow user to define target and opts
-  rpc<R>(func: string, ...args: any[]): CallRemote<R> {
-    return new CallRemote<R>(func, args);
+  rfc<F extends Func>(func: F, ...args: ParamsWithOptions<F>): RFC<Return<F>>;
+  rfc<T>(func: string, ...args: any[]): RFC<T>;
+  rfc(func: Func | string, ...args: any[]): RFC<any> {
+    if (typeof func === "function") {
+      throw new Error("not implemented");
+    }
+    return new RFC(func, ...util.splitArgsAndOpts(args, this.options()));
+  }
+
+  options(opts: Partial<Options> = {}): Options & { [RESONATE_OPTIONS]: true } {
+    return {
+      id: "",
+      target: "default",
+      timeout: 24 * util.HOUR,
+      ...opts,
+      [RESONATE_OPTIONS]: true,
+    };
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import type { Func, Params, RemoteOpts, Ret } from "./types";
+import type { Func, Params, RemoteOpts, Return } from "./types";
 import * as util from "./util";
 
 const defaultRemoteOpts: RemoteOpts = {
@@ -115,8 +115,8 @@ export class Future<T> implements Iterable<Future<T>> {
 
 export class Context {
   // TODO(avillega): Allow user to define other opts
-  beginRun<F extends Func>(func: F, ...args: Params<F>): InvokeLocal<Ret<F>> {
-    return new InvokeLocal<Ret<F>>(func, args);
+  beginRun<F extends Func>(func: F, ...args: Params<F>): InvokeLocal<Return<F>> {
+    return new InvokeLocal<Return<F>>(func, args);
   }
 
   // TODO(avillega): Allow user to define target, and opts
@@ -125,8 +125,8 @@ export class Context {
   }
 
   // TODO(avillega): Allow user to define other opts
-  run<F extends Func>(func: F, ...args: Params<F>): CallLocal<Ret<F>> {
-    return new CallLocal<Ret<F>>(func, args);
+  run<F extends Func>(func: F, ...args: Params<F>): CallLocal<Return<F>> {
+    return new CallLocal<Return<F>>(func, args);
   }
 
   // TODO(avillega): Allow user to define target and opts

--- a/src/coroutine.ts
+++ b/src/coroutine.ts
@@ -46,7 +46,7 @@ export class Coroutine<T> {
     handler: Handler,
     callback: (result: Suspended | Completed<T>) => void,
   ): void {
-    handler.createPromise<T>({ id, timeout: Number.MAX_SAFE_INTEGER, tags: {}, fn: func.name, args }, (durable) => {
+    handler.createPromise({ id, timeout: Number.MAX_SAFE_INTEGER, tags: {}, fn: func.name, args }, (durable) => {
       if (durable.state === "pending") {
         const ctx = new Context();
         const c = new Coroutine(ctx, new Decorator<T>(id, func(ctx, ...args)), handler);

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,4 +1,4 @@
-import { CallLocal, CallRemote, Future, InvokeLocal, InvokeRemote, type Yieldable } from "./context";
+import { Future, LFC, LFI, RFC, RFI, type Yieldable } from "./context";
 import type { InternalAsyncL, InternalAsyncR, InternalAwait, InternalExpr, Literal, Value } from "./types";
 import * as util from "./util";
 
@@ -81,11 +81,11 @@ export class Decorator<TRet> {
 
   // From external type to internal type
   private toInternal<T>(
-    event: InvokeLocal<T> | InvokeRemote<T> | Future<T> | CallLocal<T> | CallRemote<T>,
+    event: LFI<T> | RFI<T> | Future<T> | LFC<T> | RFC<T>,
   ): InternalAsyncL<T> | InternalAsyncR<T> | InternalAwait<T> {
-    if (event instanceof InvokeLocal || event instanceof CallLocal) {
+    if (event instanceof LFI || event instanceof LFC) {
       const id = this.idsequ();
-      this.invokes.push({ kind: event instanceof InvokeLocal ? "invoke" : "call", id });
+      this.invokes.push({ kind: event instanceof LFI ? "invoke" : "call", id });
       this.nextState = "internal.promise";
       return {
         type: "internal.async.l",
@@ -95,9 +95,9 @@ export class Decorator<TRet> {
         mode: "eager", // default, adjust if needed
       };
     }
-    if (event instanceof InvokeRemote || event instanceof CallRemote) {
+    if (event instanceof RFI || event instanceof RFC) {
       const id = this.idsequ();
-      this.invokes.push({ kind: event instanceof InvokeRemote ? "invoke" : "call", id });
+      this.invokes.push({ kind: event instanceof RFI ? "invoke" : "call", id });
       this.nextState = "internal.promise";
       return {
         type: "internal.async.r",

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,12 +16,6 @@ export interface DurablePromiseProto {
   args?: any[];
 }
 
-// export type DurablePromise<T> = {
-//   id: string;
-//   state: "pending" | "resolved" | "rejected" | "rejected_canceled" | "rejected_timedout";
-//   value?: T;
-// };
-
 export class Handler {
   private promises: Map<string, DurablePromiseRecord>;
   private network: Network;

--- a/src/handler.ts
+++ b/src/handler.ts
@@ -16,17 +16,17 @@ export interface DurablePromiseProto {
   args?: any[];
 }
 
-export type DurablePromise<T> = {
-  id: string;
-  state: "pending" | "resolved" | "rejected" | "rejected_canceled" | "rejected_timedout";
-  value?: T;
-};
+// export type DurablePromise<T> = {
+//   id: string;
+//   state: "pending" | "resolved" | "rejected" | "rejected_canceled" | "rejected_timedout";
+//   value?: T;
+// };
 
 export class Handler {
-  private promises: Map<string, DurablePromise<any>>;
+  private promises: Map<string, DurablePromiseRecord>;
   private network: Network;
 
-  constructor(network: Network, initialPromises?: DurablePromise<any>[]) {
+  constructor(network: Network, initialPromises?: DurablePromiseRecord[]) {
     this.network = network;
     this.promises = new Map();
     for (const p of initialPromises ?? []) {
@@ -38,9 +38,9 @@ export class Handler {
     this.promises.set(durablePromise.id, durablePromise);
   }
 
-  public createPromise<T>(
+  public createPromise(
     { id, timeout, tags, fn, args }: DurablePromiseProto,
-    callback: (res: DurablePromise<T>) => void,
+    callback: (res: DurablePromiseRecord) => void,
   ): void {
     const promise = this.promises.get(id);
     if (promise) {
@@ -74,7 +74,7 @@ export class Handler {
     );
   }
 
-  public resolvePromise<T>(id: string, value: T, callback: (res: DurablePromise<T>) => void): void {
+  public resolvePromise(id: string, value: any, callback: (res: DurablePromiseRecord) => void): void {
     const promise = this.promises.get(id);
     util.assertDefined(promise);
 
@@ -105,13 +105,13 @@ export class Handler {
     );
   }
 
-  public createCallback<T>(
+  public createCallback(
     id: string,
     rootPromiseId: string,
     timeout: number,
     recv: string,
     cb: (
-      result: { kind: "callback"; callback: CallbackRecord } | { kind: "promise"; promise: DurablePromise<T> },
+      result: { kind: "callback"; callback: CallbackRecord } | { kind: "promise"; promise: DurablePromiseRecord },
     ) => void,
   ): void {
     this.network.send(

--- a/src/network/remote.ts
+++ b/src/network/remote.ts
@@ -253,6 +253,11 @@ export class HttpNetwork implements Network {
       return;
     }
 
+    if (data?.type === "notify" && util.isDurablePromiseRecord(data?.promise)) {
+      this.onMessage?.({ type: "notify", promise: this.mapPromiseDtoToRecord(data.promise) }, () => {});
+      return;
+    }
+
     console.warn("couldn't parse", data, "as a message");
   }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -1,17 +1,28 @@
 import type { Func } from "./types";
 
+type Item = {
+  name: string;
+  func: Func;
+};
+
 export class Registry {
-  public funcs: Map<string, Func> = new Map();
+  public forward_registry: Map<string, Item> = new Map();
+  public reverse_registry: Map<Func, Item> = new Map();
 
-  get(id: string): Func | undefined {
-    return this.funcs.get(id);
+  get(nameOrFunc: string | Func): Item | undefined {
+    return typeof nameOrFunc === "string"
+      ? this.forward_registry.get(nameOrFunc)
+      : this.reverse_registry.get(nameOrFunc);
   }
 
-  set(id: string, func: Func): void {
-    this.funcs.set(id, func);
+  has(nameOrFunc: string | Func): boolean {
+    return typeof nameOrFunc === "string"
+      ? this.forward_registry.has(nameOrFunc)
+      : this.reverse_registry.has(nameOrFunc);
   }
 
-  has(id: string): boolean {
-    return this.funcs.has(id);
+  set(name: string, func: Func): void {
+    this.forward_registry.set(name, { name, func });
+    this.reverse_registry.set(func, { name, func });
   }
 }

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -23,7 +23,6 @@ export class Resonate {
   private group: string;
   private pid: string;
   private ttl: number;
-  // private handlerPromises: Map<string, PromiseWithResolvers<any>>;
 
   constructor(network: Network, config: { group: string; pid: string; ttl: number }) {
     this.network = network;

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -1,18 +1,20 @@
 import { LocalNetwork } from "../dev/network";
-import type { CreatePromiseAndTaskRes, Network } from "./network/network";
+import type { CreatePromiseAndTaskRes, CreatePromiseRes, CreateSubscriptionRes, DurablePromiseRecord, Network } from "./network/network";
 import { HttpNetwork } from "./network/remote";
 import { ResonateInner } from "./resonate-inner";
-import type { Func, Params, Ret } from "./types";
+import type { Func, Params, Return } from "./types";
 import * as util from "./util";
 
-export interface InvocationHandler<T> {
+export interface Handle<T> {
   result: Promise<T>;
 }
 
-export interface RegisteredFunc<F extends Func> {
-  fn: F;
+export interface ResonateFunc<F extends Func> {
+  run: (id: string, ...args: Params<F>) => Promise<Return<F>>;
+  rpc: (id: string, ...args: Params<F>) => Promise<Return<F>>;
+  beginRun: (id: string, ...args: Params<F>) => Promise<Handle<Return<F>>>;
+  beginRpc: (id: string, ...args: Params<F>) => Promise<Handle<Return<F>>>;
   options: () => void;
-  beginRun: (id: string, ...args: Params<F>) => Promise<InvocationHandler<Ret<F>>>;
 }
 
 export class Resonate {
@@ -21,42 +23,40 @@ export class Resonate {
   private group: string;
   private pid: string;
   private ttl: number;
-  private handlerPromises: Map<string, PromiseWithResolvers<any>>;
+  // private handlerPromises: Map<string, PromiseWithResolvers<any>>;
 
   constructor(network: Network, config: { group: string; pid: string; ttl: number }) {
     this.network = network;
-    this.handlerPromises = new Map();
     this.group = config.group;
     this.pid = config.pid;
     this.ttl = config.ttl;
     this.inner = new ResonateInner(network, config);
-    this.inner.onComplete(({ promiseId, value }) => {
-      const p = this.handlerPromises.get(promiseId);
-      if (p) {
-        // TODO(avillega): Handler rejections
-        p.resolve(value);
-      }
-    });
   }
 
   /**
    * Create a local Resonate instance
    */
   static local(): Resonate {
-    return new Resonate(new LocalNetwork(), { group: "default", pid: "default", ttl: 1 * util.MIN });
+    return new Resonate(new LocalNetwork(), {
+      group: "default",
+      pid: "default",
+      ttl: 1 * util.MIN,
+    });
   }
 
   /**
    * Create a remote Resonate instance
    */
-  static remote(config: {
-    host?: string;
-    storePort?: string;
-    messageSourcePort?: string;
-    group?: string;
-    pid?: string;
-    ttl?: number;
-  }): Resonate {
+  static remote(
+    config: {
+      host?: string;
+      storePort?: string;
+      messageSourcePort?: string;
+      group?: string;
+      pid?: string;
+      ttl?: number;
+    } = {},
+  ): Resonate {
     const pid = config.pid ?? crypto.randomUUID();
     const group = config.group ?? "default";
     const ttl = config.ttl ?? 10 * util.SEC;
@@ -75,25 +75,50 @@ export class Resonate {
   }
 
   /**
-   * Invoke a function and return a Promise
+   * Register a function and returns a registered function
    */
-  public async beginRun<T>(id: string, funcName: string, ...args: any[]): Promise<InvocationHandler<T>> {
-    const func = this.inner.registry.get(funcName); // TODO(avillega): should the register be owned by Resonate?
-    if (!func) {
-      throw new Error(`${funcName} does not exists`);
+  public register<F extends Func>(func: F, name?: string): ResonateFunc<F> {
+    this.inner.register(name ?? func.name, func);
+
+    return {
+      run: (id: string, ...args: Params<F>): Promise<Return<F>> => this.run(id, func, ...args),
+      rpc: (id: string, ...args: Params<F>): Promise<Return<F>> => this.rpc(id, func, ...args),
+      beginRun: (id: string, ...args: Params<F>): Promise<Handle<Return<F>>> => this.beginRun(id, func, ...args),
+      beginRpc: (id: string, ...args: Params<F>): Promise<Handle<Return<F>>> => this.beginRpc(id, func, ...args),
+      options: () => {},
+    };
+  }
+
+  /**
+   * Invoke a function and return a value
+   */
+  public async run<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Return<F>>;
+  public async run<T>(id: string, name: string, ...args: any[]): Promise<T>;
+  public async run<T>(id: string, funcOrName: Func | string, ...args: any[]): Promise<T>;
+  public async run(id: string, funcOrName: Func | string, ...args: any[]): Promise<any> {
+    return (await this.beginRun(id, funcOrName, ...args)).result;
+  }
+
+  /**
+   * Invoke a function and return a promise
+   */
+  public async beginRun<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Handle<Return<F>>>;
+  public async beginRun<T>(id: string, func: string, ...args: any[]): Promise<Handle<T>>;
+  public async beginRun(id: string, funcOrName: Func | string, ...args: any[]): Promise<Handle<any>>;
+  public async beginRun(id: string, funcOrName: Func | string, ...args: any[]): Promise<Handle<any>> {
+    const registered = this.inner.registry.get(funcOrName); // TODO(avillega): should the register be owned by Resonate?
+    if (!registered) {
+      throw new Error(`${funcOrName} does not exist`);
     }
 
-    return new Promise<InvocationHandler<T>>((resolve, _reject) => {
+    return new Promise<Handle<any>>((resolve) => {
       this.network.send(
         {
           kind: "createPromiseAndTask",
           promise: {
             id: id,
             timeout: 24 * util.HOUR + Date.now(), // TODO(avillega): use option timeout or 24h. Check the  usage of Date here, seems fine
-            param: {
-              fn: funcName,
-              args,
-            },
+            param: { func: registered.name, args },
             tags: { "resonate:invoke": `poll://any@${this.group}/${this.pid}` }, // TODO(avillega): use the real anycast address or change the server to not require `poll://`
           },
           task: {
@@ -103,49 +128,153 @@ export class Resonate {
           iKey: id,
           strict: false,
         },
-        (timeout, res) => {
+        (timeout, response) => {
+          const res = response as CreatePromiseAndTaskRes;
+
           if (timeout) {
-            console.error("Something went wrong reaching the resonate server");
             // TODO(avillega): Handle platform level error
-          }
-
-          const { promise: durable, task } = res as CreatePromiseAndTaskRes;
-          const resultPromise = Promise.withResolvers<T>();
-          const iHandler = { result: resultPromise.promise };
-          this.handlerPromises.set(durable.id, resultPromise);
-
-          if (durable.state === "resolved") {
-            resultPromise.resolve(durable.value);
-            resolve(iHandler);
+            console.error("Platform error");
             return;
           }
 
-          if (!task) {
+          // create and resolve a handle now that the durable promise
+          // has been created
+          const promise = Promise.withResolvers();
+          resolve({ result: promise.promise });
+
+          // check if the promise is complete and early exit
+          if (this.complete(res.promise, promise.resolve, promise.reject)) {
+            return;
+          }
+
+          if (!res.task) {
             console.log("got no task, should create a sub for the promise instead");
             // TODO(avillega): Create sub for the promise and return
             return;
           }
 
-          this.inner.process({ ...task, kind: "claimed", rootPromise: durable }, () => {}); // TODO(avillega): Handle failure and platform errors in callback
-          resolve(iHandler);
+          // TODO(avillega): Handle failure and platform errors in callback
+          this.inner.process(
+            {
+              kind: "claimed",
+              rootPromise: res.promise,
+              ...res.task,
+            },
+            (res) => {
+              if (res.kind === "completed") {
+                this.complete(res.promise, promise.resolve, promise.reject);
+              }
+            },
+          );
         },
       );
     });
   }
 
   /**
-   * Register a function and returns a registered function
+   * Invoke a remote function and return a value
    */
-  public register<F extends Func>(name: string, func: F): RegisteredFunc<F> {
-    this.inner.register(name, func);
+  public async rpc<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Return<F>>;
+  public async rpc<T>(id: string, name: string, ...args: any[]): Promise<T>;
+  public async rpc<T>(id: string, funcOrName: Func | string, ...args: any[]): Promise<T>;
+  public async rpc(id: string, funcOrName: Func | string, ...args: any[]): Promise<any> {
+    return (await this.beginRpc(id, funcOrName, ...args)).result;
+  }
 
-    return {
-      fn: func,
-      beginRun: (id: string, ...args: Params<F>): Promise<InvocationHandler<Ret<F>>> => {
-        return this.beginRun(id, name, ...args);
-      },
-      options: () => {},
-    };
+  /**
+   * Invoke a remote function and return a promise
+   */
+  public async beginRpc<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Handle<Return<F>>>;
+  public async beginRpc<T>(id: string, func: string, ...args: any[]): Promise<Handle<T>>;
+  public async beginRpc(id: string, funcOrName: Func | string, ...args: any[]): Promise<Handle<any>>;
+  public async beginRpc(id: string, funcOrName: Func | string, ...args: any[]): Promise<Handle<any>> {
+    const registered = this.inner.registry.get(funcOrName); // TODO(avillega): should the register be owned by Resonate?
+    if (!registered) {
+      throw new Error(`${funcOrName} does not exist`);
+    }
+
+    return new Promise<Handle<any>>((resolve) => {
+      this.network.send(
+        {
+          kind: "createPromise",
+          id: id,
+          timeout: 24 * util.HOUR + Date.now(), // TODO(avillega): use option timeout or 24h. Check the  usage of Date here, seems fine
+          param: { func: registered.name, args },
+          tags: { "resonate:invoke": `poll://any@${this.group}` }, // TODO(avillega): use the real anycast address or change the server to not require `poll://`
+          iKey: id,
+          strict: false,
+        },
+        (timeout, response) => {
+          const res = response as CreatePromiseRes;
+
+          if (timeout) {
+            // TODO(avillega): Handle platform level error
+            console.error("Platform error");
+            return;
+          }
+
+          // create and resolve a handle now that the durable promise
+          // has been created
+          const promise = Promise.withResolvers();
+          resolve({ result: promise.promise });
+
+          // check if the promise is complete and early exit
+          if (this.complete(res.promise, promise.resolve, promise.reject)) {
+            return;
+          }
+
+          // otherwise create subscription
+          this.network.send(
+            {
+              kind: "createSubscription",
+              id: id,
+              timeout: 24 * util.HOUR + Date.now(), // TODO(avillega): use option timeout or 24h. Check the  usage of Date here, seems fine
+              recv: `poll://uni@${this.group}/${this.pid}`,
+            },
+            (timeout, response) => {
+              const res = response as CreateSubscriptionRes;
+
+              if (timeout) {
+                // TODO(avillega): Handle platform level error
+                console.error("Platform error");
+                return;
+              }
+
+              // once again check if the promise is complete and early exit
+              if (this.complete(res.promise, promise.resolve, promise.reject)) {
+                return;
+              }
+
+              // otherwise register a subscription
+              this.inner.subscribe(id, (p) => this.complete(p, promise.resolve, promise.reject));
+            },
+          );
+        },
+      );
+    });
+  }
+
+  private complete(promise: DurablePromiseRecord, resolve: (v: any) => void, reject: (e?: any) => void) {
+    if (promise.state === "resolved") {
+      resolve(promise.value);
+      return true;
+    }
+    if (promise.state === "rejected") {
+      reject(promise.value);
+      return true;
+    }
+    if (promise.state === "rejected_canceled") {
+      // TODO: reject with specific error
+      reject(new Error("Promise canceled"));
+      return true;
+    }
+    if (promise.state === "rejected_timedout") {
+      // TODO: reject with specific error
+      reject(new Error("Promise timedout"));
+      return true;
+    }
+
+    return false;
   }
 
   public stop() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export type LocalOpts = {
   timeout: number;
 };
 
-export type Completed = { kind: "completed"; promiseId: string; result: any };
+export type Completed = { kind: "completed"; promise: DurablePromiseRecord };
 export type Suspended = { kind: "suspended"; promiseId: string };
 export type Failure = { kind: "failure"; task: Task };
 export type PlatformError = { kind: "platformError"; cause: any; msg: string };
@@ -42,7 +42,7 @@ export type UnclaimedTask = {
 export type Task = UnclaimedTask | ClaimedTask;
 
 // Return type of a function or a generator
-export type Ret<T> = T extends (...args: any[]) => Generator<infer Y, infer R, infer N>
+export type Return<T> = T extends (...args: any[]) => Generator<infer Y, infer R, infer N>
   ? R // Return type of generator
   : T extends (...args: any[]) => infer R
     ? Awaited<R> // Return type of regular function

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,17 +3,14 @@ import type { DurablePromiseRecord } from "./network/network";
 
 export type Func = (ctx: Context, ...args: any[]) => any;
 
+export const RESONATE_OPTIONS: unique symbol = Symbol("ResonateOptions");
+
 // The args of a resonate function excluding the context argument
 export type Params<F> = F extends (ctx: Context, ...args: infer P) => any ? P : never;
+export type ParamsWithOptions<F> = [...Params<F>, (Partial<Options> & { [RESONATE_OPTIONS]: true })?];
 
-export type RemoteOpts = {
-  id?: string;
-  target: string;
-  timeout: number;
-};
-
-export type LocalOpts = {
-  id?: string;
+export type Options = {
+  id: string;
   target: string;
   timeout: number;
 };
@@ -56,7 +53,7 @@ export type InternalAsyncR<T> = {
   id: string;
   func: string;
   args: any[];
-  opts: RemoteOpts;
+  opts: Options;
   mode: "eager" | "defer"; // TODO(avillega): Right now it is unused, review its usage
 };
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,9 +42,24 @@ export function isTaskRecord(obj: any): obj is TaskRecord {
   );
 }
 
-export function isDurablePromiseRecord(obj: any): obj is DurablePromiseRecord {
-  // TODO(dfarr): complete this type guard
-  return typeof obj === "object" && obj !== null && typeof obj.id === "string" && typeof obj.state === "string";
+export function isDurablePromiseRecord(obj: unknown): obj is DurablePromiseRecord {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    typeof (obj as any).id === "string" &&
+    typeof (obj as any).timeout === "number" &&
+    typeof (obj as any).param !== "undefined" && // allow any type
+    typeof (obj as any).value !== "undefined" && // allow any type
+    typeof (obj as any).tags === "object" &&
+    (obj as any).tags !== null &&
+    !Array.isArray((obj as any).tags) &&
+    Object.values((obj as any).tags).every((v) => typeof v === "string") &&
+    ["pending", "resolved", "rejected", "rejected_canceled", "rejected_timedout"].includes((obj as any).state) &&
+    (typeof (obj as any).iKeyForCreate === "undefined" || typeof (obj as any).iKeyForCreate === "string") &&
+    (typeof (obj as any).iKeyForComplete === "undefined" || typeof (obj as any).iKeyForComplete === "string") &&
+    (typeof (obj as any).createdOn === "undefined" || typeof (obj as any).createdOn === "number") &&
+    (typeof (obj as any).completedOn === "undefined" || typeof (obj as any).completedOn === "number")
+  );
 }
 
 export function isOptions(value: unknown): value is Options {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import type { TaskRecord } from "./network/network";
+import type { DurablePromiseRecord, TaskRecord } from "./network/network";
 
 // Base unit: milliseconds
 export const MS = 1;
@@ -39,4 +39,9 @@ export function isTaskRecord(obj: any): obj is TaskRecord {
     (obj.createdOn === undefined || typeof obj.createdOn === "number") &&
     (obj.completedOn === undefined || typeof obj.completedOn === "number")
   );
+}
+
+export function isDurablePromiseRecord(obj: any): obj is DurablePromiseRecord {
+  // TODO(dfarr): complete this type guard
+  return typeof obj === "object" && obj !== null && typeof obj.id === "string" && typeof obj.state === "string";
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -62,8 +62,8 @@ export function isDurablePromiseRecord(obj: unknown): obj is DurablePromiseRecor
   );
 }
 
-export function isOptions(value: unknown): value is Options {
-  return !!value && typeof value === "object" && RESONATE_OPTIONS in value;
+export function isOptions(obj: unknown): obj is Options {
+  return typeof obj === "object" && obj !== null && RESONATE_OPTIONS in obj;
 }
 
 export function splitArgsAndOpts(args: any[], defaults: Options): [any[], Options] {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import type { DurablePromiseRecord, TaskRecord } from "./network/network";
+import { type Options, RESONATE_OPTIONS } from "./types";
 
 // Base unit: milliseconds
 export const MS = 1;
@@ -17,14 +18,14 @@ export function assert(cond: boolean, msg?: string): void {
   }
 }
 
+export function assertDefined<T>(val: T | undefined | null): asserts val is T {
+  assert(val !== null && val !== undefined, "value must not be null");
+}
+
 export function isGeneratorFunction(fn: Function): boolean {
   const GeneratorFunction = Object.getPrototypeOf(function* () {}).constructor;
   const AsyncGeneratorFunction = Object.getPrototypeOf(async function* () {}).constructor;
   return fn instanceof GeneratorFunction || fn instanceof AsyncGeneratorFunction;
-}
-
-export function assertDefined<T>(val: T | undefined | null): asserts val is T {
-  assert(val !== null && val !== undefined, "value must not be null");
 }
 
 export function isTaskRecord(obj: any): obj is TaskRecord {
@@ -44,4 +45,13 @@ export function isTaskRecord(obj: any): obj is TaskRecord {
 export function isDurablePromiseRecord(obj: any): obj is DurablePromiseRecord {
   // TODO(dfarr): complete this type guard
   return typeof obj === "object" && obj !== null && typeof obj.id === "string" && typeof obj.state === "string";
+}
+
+export function isOptions(value: unknown): value is Options {
+  return !!value && typeof value === "object" && RESONATE_OPTIONS in value;
+}
+
+export function splitArgsAndOpts(args: any[], defaults: Options): [any[], Options] {
+  const opts = isOptions(args.at(-1)) ? args.pop() : {};
+  return [args, { ...defaults, ...opts }];
 }

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -68,7 +68,7 @@ describe("Coroutine", () => {
     }
 
     function* foo(ctx: Context) {
-      const p = yield* ctx.beginRun(bar);
+      const p = yield* ctx.lfi(bar);
       const v = yield* p;
       return v;
     }
@@ -87,8 +87,8 @@ describe("Coroutine", () => {
     }
 
     function* foo(ctx: Context) {
-      const p = yield* ctx.beginRun(bar);
-      const p2 = yield* ctx.beginRun(baz);
+      const p = yield* ctx.lfi(bar);
+      const p2 = yield* ctx.lfi(baz);
       const v = yield* p;
       const v2 = yield* p2;
       return v + v2;
@@ -115,8 +115,8 @@ describe("Coroutine", () => {
     }
 
     function* foo(ctx: Context) {
-      const p1 = yield* ctx.beginRun(bar);
-      const p2 = yield* ctx.beginRpc("bar");
+      const p1 = yield* ctx.lfi(bar);
+      const p2 = yield* ctx.rfi("bar");
       const v1 = yield* p1;
       const vx = yield* p1;
       const v2 = yield* p2;
@@ -141,8 +141,8 @@ describe("Coroutine", () => {
     }
 
     function* foo(ctx: Context) {
-      yield* ctx.beginRpc("bar");
-      yield* ctx.beginRpc("bar");
+      yield* ctx.rfi("bar");
+      yield* ctx.rfi("bar");
       return 99;
     }
 
@@ -172,8 +172,8 @@ describe("Coroutine", () => {
     }
 
     function* foo(ctx: Context) {
-      const v1: number = yield* ctx.run(bar);
-      const v2: number = yield* ctx.rpc<number>("bar");
+      const v1: number = yield* ctx.lfc(bar);
+      const v2: number = yield* ctx.rfc<number>("bar");
       return v1 + v2;
     }
 

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -1,10 +1,10 @@
 import { Decorator } from "../src/decorator";
 
-import { Context, Future, type InvokeLocal } from "../src/context";
+import { Context, Future, type LFI } from "../src/context";
 
 describe("Decorator", () => {
   it("returns internal.return when generator is done", () => {
-    function* foo(): Generator<InvokeLocal<any> | Future<any>, any, number> {
+    function* foo(): Generator<LFI<any> | Future<any>, any, number> {
       return 42;
     }
 
@@ -21,8 +21,8 @@ describe("Decorator", () => {
   });
 
   it("handles internal.async correctly", () => {
-    function* foo(ctx: Context): Generator<InvokeLocal<any>, any, any> {
-      yield* ctx.beginRun(() => 42);
+    function* foo(ctx: Context): Generator<LFI<any>, any, any> {
+      yield* ctx.lfi(() => 42);
     }
 
     const d = new Decorator("abc", foo(new Context()));
@@ -53,8 +53,8 @@ describe("Decorator", () => {
 
   it("handles lfc/rfc correctly", () => {
     function* foo(ctx: Context): Generator<any, any, any> {
-      const v1 = yield* ctx.run((ctx: Context, x: number) => x + 1, 1);
-      const v2 = yield* ctx.rpc<number>("foo");
+      const v1 = yield* ctx.lfc((ctx: Context, x: number) => x + 1, 1);
+      const v2 = yield* ctx.rfc<number>("foo");
       return v1 + v2;
     }
 
@@ -111,9 +111,9 @@ describe("Decorator", () => {
   });
 
   it("returns final value after multiple yields", () => {
-    function* foo(ctx: Context): Generator<InvokeLocal<any> | Future<any>, any, number> {
+    function* foo(ctx: Context): Generator<LFI<any> | Future<any>, any, number> {
       yield new Future("future-1", "completed", 10);
-      yield* ctx.beginRun(() => 42);
+      yield* ctx.lfi(() => 42);
       return 30;
     }
 
@@ -141,10 +141,10 @@ describe("Decorator", () => {
   });
 
   it("awaits if there are pending invokes - Structured Concurrency", () => {
-    function* foo(ctx: Context): Generator<InvokeLocal<any> | Future<any>, any, number> {
+    function* foo(ctx: Context): Generator<LFI<any> | Future<any>, any, number> {
       yield new Future("future-1", "completed", 10); // A
-      yield* ctx.beginRun(() => 20); // B
-      yield* ctx.beginRun(() => 30); // C
+      yield* ctx.lfi(() => 20); // B
+      yield* ctx.lfi(() => 30); // C
       return 30; // D
     }
 
@@ -178,10 +178,10 @@ describe("Decorator", () => {
   });
 
   it("returns if there are no pending invokes even if not explecityly awaited", () => {
-    function* foo(ctx: Context): Generator<InvokeLocal<any> | Future<any>, any, number> {
+    function* foo(ctx: Context): Generator<LFI<any> | Future<any>, any, number> {
       yield new Future("future-1", "completed", 10); // A
-      yield* ctx.beginRun(() => 20); // B
-      yield* ctx.beginRun(() => 30); // C
+      yield* ctx.lfi(() => 20); // B
+      yield* ctx.lfi(() => 30); // C
       return 42; // D
     }
 


### PR DESCRIPTION
```ts
// run
public async run<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Return<F>>;
public async run<T>(id: string, name: string, ...args: any[]): Promise<T>;

// rpc
public async rpc<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Return<F>>;
public async rpc<T>(id: string, name: string, ...args: any[]): Promise<T>;

// beginRun
public async beginRun<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Handle<Return<F>>>;
public async beginRun<T>(id: string, func: string, ...args: any[]): Promise<Handle<T>>;

// beginRpc
public async beginRpc<F extends Func>(id: string, func: F, ...args: Params<F>): Promise<Handle<Return<F>>>;
public async beginRpc<T>(id: string, func: string, ...args: any[]): Promise<Handle<T>>;
```