### PR TITLE
Fix concurrency bug

### DIFF
--- a/src/computation.ts
+++ b/src/computation.ts
@@ -220,6 +220,7 @@ export class Computation {
 
   private handleRemoteTodos(taskId: string, todos: RemoteTodo[]) {
     let createdCallbacks = 0;
+    let returnedTodo = false;
     const totalCallbacks = todos.length;
 
     for (const remoteTodo of todos) {
@@ -230,7 +231,8 @@ export class Computation {
         Number.MAX_SAFE_INTEGER, // TODO (avillega): use the promise timeout
         `poll://any@${this.group}/${this.pid}`,
         (result) => {
-          if (result.kind === "promise") {
+          if (result.kind === "promise" && !returnedTodo) {
+            returnedTodo = true;
             this.enqueue(taskId, "return");
             return;
           }


### PR DESCRIPTION
This adds another layer to the ways we are trying to squash all possibilities of a race condition.

In this case, we are only re executing the computation on the first callback that comes as an already completed promise and ignoring the rest.