### PR TITLE
Add nursery

### DIFF
--- a/dev/server.ts
+++ b/dev/server.ts
@@ -4,9 +4,9 @@ import type {
   CallbackRecord,
   DurablePromiseRecord,
   Mesg,
-  RecvMsg,
-  RequestMsg,
-  ResponseMsg,
+  Message,
+  Request,
+  Response,
   ScheduleRecord,
   TaskRecord,
 } from "../src/network/network";
@@ -149,7 +149,7 @@ export class Server {
     return timeout;
   }
 
-  step(time: number): { msg: RecvMsg; recv: string }[] {
+  step(time: number): { msg: Message; recv: string }[] {
     for (const schedule of this.schedules.values()) {
       util.assertDefined(schedule.nextRunTime);
       if (time < schedule.nextRunTime) {
@@ -199,13 +199,13 @@ export class Server {
       }
     }
 
-    const msgs: { msg: RecvMsg; recv: string }[] = [];
+    const msgs: { msg: Message; recv: string }[] = [];
     for (const task of this.tasks.values()) {
       if (task.state !== "init" || inFlightRootPromiseIds.has(task.rootPromiseId)) {
         continue;
       }
 
-      let msg: { msg: RecvMsg; recv: string };
+      let msg: { msg: Message; recv: string };
       if (task.type === "invoke") {
         msg = {
           msg: {
@@ -254,7 +254,7 @@ export class Server {
     return msgs;
   }
 
-  process(requ: RequestMsg, time: number): ResponseMsg {
+  process(requ: Request, time: number): Response {
     try {
       switch (requ.kind) {
         case "createPromise": {

--- a/sim/main.ts
+++ b/sim/main.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import type * as context from "../src/context";
-import type { RequestMsg } from "../src/network/network";
+import type { Request } from "../src/network/network";
 import { ServerProcess } from "./src/server";
 import { Message, Random, Simulator, unicast } from "./src/simulator";
 import { WorkerProcess } from "./src/worker";
@@ -199,13 +199,13 @@ export function run(options: Options) {
     if (!options.func || i === 0) {
       const id = `${funcName}-${i}`;
       const timeout = rnd.randint(0, options.steps);
-      let msg: Message<RequestMsg>;
+      let msg: Message<Request>;
       switch (funcName) {
         case "fibLfi":
         case "fibLfc":
         case "fibRfi":
         case "fibRfc": {
-          msg = new Message<RequestMsg>(
+          msg = new Message<Request>(
             unicast("environment"),
             unicast("server"),
             {
@@ -223,7 +223,7 @@ export function run(options: Options) {
         case "foo":
         case "bar":
         case "baz": {
-          msg = new Message<RequestMsg>(
+          msg = new Message<Request>(
             unicast("environment"),
             unicast("server"),
             {

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -92,10 +92,7 @@ export class Computation {
   }
 
   private processClaimed(task: ClaimedTask, done: Callback<Status>) {
-    util.assert(
-      task.rootPromiseId === this.id,
-      "task root promise id must match computation id",
-    );
+    util.assert(task.rootPromiseId === this.id, "task root promise id must match computation id");
 
     if (this.nurseries.has(task.rootPromise.id)) {
       // TODO: log something useful
@@ -158,10 +155,7 @@ export class Computation {
           break;
 
         case "suspended":
-        util.assert(
-          status.todo.local.length > 0 || status.todo.remote.length > 0,
-          "must be at least one todo",
-        );
+          util.assert(status.todo.local.length > 0 || status.todo.remote.length > 0, "must be at least one todo");
 
           // local todos
           if (status.todo.local.length > 0) {

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -1,5 +1,3 @@
-import type { CompResult } from "../types";
-
 export interface DurablePromiseRecord {
   id: string;
   state: "pending" | "resolved" | "rejected" | "rejected_canceled" | "rejected_timedout";
@@ -164,7 +162,7 @@ export type HeartbeatTasksReq = {
 };
 
 // Union of all request types
-export type RequestMsg =
+export type Request =
   | CreatePromiseReq
   | CreatePromiseAndTaskReq
   | ReadPromiseReq
@@ -254,7 +252,7 @@ export type ErrorRes = {
 };
 
 // Union of all response types
-export type ResponseMsg =
+export type Response =
   | CreatePromiseRes
   | CreatePromiseAndTaskRes
   | ReadPromiseRes
@@ -270,15 +268,13 @@ export type ResponseMsg =
   | HeartbeatTasksRes
   | ErrorRes;
 
-export type RecvMsg =
+export type Message =
   | { type: "invoke" | "resume"; task: TaskRecord }
   | { type: "notify"; promise: DurablePromiseRecord };
 
 export interface Network {
-  send(request: RequestMsg, callback: (timeout: boolean, response: ResponseMsg) => void): void;
-  recv(msg: any): void;
+  send(req: Request, callback: (err: boolean, res: Response) => void): void;
+  recv(msg: Message): void;
   stop(): void;
-
-  // Provided by the user of the network, interface
-  onMessage?: (msg: RecvMsg, cb: (res: CompResult) => void) => void;
+  subscribe(callback: (msg: Message) => void): void;
 }

--- a/src/nursery.ts
+++ b/src/nursery.ts
@@ -1,15 +1,15 @@
-export class Nursery {
+export class Nursery<E, R> {
   private q: Array<() => void> = [];
   private f: () => void;
-  private c: (e: any, r: any) => void;
-  private e?: any;
-  private r?: any;
+  private c: (e: E, r: R) => void;
+  private e?: E;
+  private r?: R;
 
   private holds = 0;
   private running = false;
   private completed = false;
 
-  constructor(f: (n: Nursery) => void, c: (e: any, r: any) => void) {
+  constructor(f: (n: Nursery<E, R>) => void, c: (e: any, r: any) => void) {
     this.f = () => f(this);
     this.c = c;
 
@@ -36,7 +36,7 @@ export class Nursery {
     this.running = false;
   }
 
-  done(err: any, res?: any) {
+  done(err: E, res?: R) {
     if (!this.running || this.completed) return;
 
     this.e = err;
@@ -63,6 +63,6 @@ export class Nursery {
 
   private complete() {
     if (!this.completed || this.holds > 0) return;
-    this.c(this.e, this.r);
+    this.c(this.e!, this.r!);
   }
 }

--- a/src/nursery.ts
+++ b/src/nursery.ts
@@ -5,8 +5,9 @@ export class Nursery {
   private e?: any;
   private r?: any;
 
-  private running = false;
   private holds = 0;
+  private running = false;
+  private completed = false;
 
   constructor(f: (n: Nursery) => void, c: (e: any, r: any) => void) {
     this.f = () => f(this);
@@ -14,10 +15,6 @@ export class Nursery {
 
     // kick off the nursery
     this.enqueue(this.f);
-  }
-
-  get completed() {
-    return this.e || this.r;
   }
 
   hold(f: (f: () => void) => void) {
@@ -35,15 +32,18 @@ export class Nursery {
     });
   }
 
-  done(err?: any, res?: any) {
-    if (!this.running || this.completed) return;
+  cont() {
     this.running = false;
+  }
 
-    if (err || res) {
-      this.e = err;
-      this.r = res;
-      this.complete();
-    }
+  done(err: any, res?: any) {
+    if (!this.running || this.completed) return;
+
+    this.e = err;
+    this.r = res;
+    this.running = false;
+    this.completed = true;
+    this.complete();
   }
 
   private enqueue(f: () => void) {

--- a/src/nursery.ts
+++ b/src/nursery.ts
@@ -1,8 +1,19 @@
 export class Nursery<E, R> {
+  // event queue, these functions are ensured to execute sequentially
   private q: Array<() => void> = [];
+
+  // the function the nursery is instantiated with, added to the
+  // queue when holds are released
   private f: () => void;
+
+  // the callback the nursery is instantiated with, called once when
+  // the nursery is done and all holds are released
   private c: (e?: E, r?: R) => void;
+
+  // the error value done is called with, if any
   private e?: E;
+
+  // the return value done is called with, if any
   private r?: R;
 
   private holds = 0;

--- a/src/nursery.ts
+++ b/src/nursery.ts
@@ -1,0 +1,68 @@
+export class Nursery {
+  private q: Array<() => void> = [];
+  private f: () => void;
+  private c: (e: any, r: any) => void;
+  private e?: any;
+  private r?: any;
+
+  private running = false;
+  private holds = 0;
+
+  constructor(f: (n: Nursery) => void, c: (e: any, r: any) => void) {
+    this.f = () => f(this);
+    this.c = c;
+
+    // kick off the nursery
+    this.enqueue(this.f);
+  }
+
+  get completed() {
+    return this.e || this.r;
+  }
+
+  hold(f: (f: () => void) => void) {
+    if (!this.running || this.completed) return;
+    this.holds++;
+
+    f(() => {
+      this.holds--;
+
+      if (this.completed) {
+        this.complete();
+      } else {
+        this.enqueue(this.f);
+      }
+    });
+  }
+
+  done(err?: any, res?: any) {
+    if (!this.running || this.completed) return;
+    this.running = false;
+
+    if (err || res) {
+      this.e = err;
+      this.r = res;
+      this.complete();
+    }
+  }
+
+  private enqueue(f: () => void) {
+    this.q.push(f);
+    this.execute();
+  }
+
+  private execute() {
+    if (this.running) return;
+
+    const f = this.q.shift();
+    if (f) {
+      this.running = true;
+      f();
+    }
+  }
+
+  private complete() {
+    if (!this.completed || this.holds > 0) return;
+    this.c(this.e, this.r);
+  }
+}

--- a/src/resonate-inner.ts
+++ b/src/resonate-inner.ts
@@ -1,8 +1,9 @@
 import type { Heartbeat } from "heartbeat";
-import { Computation } from "./computation";
-import type { DurablePromiseRecord, Network, RecvMsg } from "./network/network";
+import { Computation, type Status } from "./computation";
+import type { DurablePromiseRecord, Message, Network } from "./network/network";
 import { Registry } from "./registry";
-import type { CompResult, Func, Task } from "./types";
+import type { Callback, Func, Task } from "./types";
+import * as util from "./util";
 
 export class ResonateInner {
   public registry: Registry; // TODO(avillega): Who should own the registry? the resonate class?
@@ -25,38 +26,42 @@ export class ResonateInner {
     this.heartbeat = heartbeat;
     this.registry = new Registry();
     this.network = network;
-    this.network.onMessage = this.onMessage.bind(this);
+    this.network.subscribe(this.onMessage.bind(this));
   }
 
-  public process(t: Task, cb: (res: CompResult) => void) {
-    let computation = this.computations.get(t.rootPromiseId);
+  public process(task: Task, callback: Callback<Status>) {
+    let computation = this.computations.get(task.rootPromiseId);
     if (!computation) {
       computation = new Computation(
-        t.rootPromiseId,
-        this.network,
-        this.registry,
-        this.group,
+        task.rootPromiseId,
         this.pid,
         this.ttl,
+        this.group,
+        this.network,
+        this.registry,
         this.heartbeat,
       );
-      this.computations.set(t.rootPromiseId, computation);
+      this.computations.set(task.rootPromiseId, computation);
     }
 
-    computation.process(t, (res) => {
-      // notify subscribers
-      if (res.kind === "completed") {
-        this.notify(res.durablePromise);
+    computation.process(task, (err, status) => {
+      if (err) callback(err);
+      util.assertDefined(status);
+
+      callback(false, status);
+
+      if (status.kind === "completed") {
+        // notify subscribers of the completed promise
+        this.notify(status.promise);
       }
-      cb(res);
     });
   }
 
-  private onMessage(msg: RecvMsg, cb: (res: CompResult) => void): void {
+  private onMessage(msg: Message): void {
     switch (msg.type) {
       case "invoke":
       case "resume":
-        this.process({ ...msg.task, kind: "unclaimed" }, cb);
+        this.process({ ...msg.task, kind: "unclaimed" }, () => {});
         break;
 
       case "notify":

--- a/src/resonate-inner.ts
+++ b/src/resonate-inner.ts
@@ -45,7 +45,7 @@ export class ResonateInner {
     }
 
     computation.process(task, (err, status) => {
-      if (err) callback(err);
+      if (err) return callback(err);
       util.assertDefined(status);
 
       callback(false, status);

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,11 +15,12 @@ export type Options = {
   timeout: number;
 };
 
-export type Completed = { kind: "completed"; durablePromise: DurablePromiseRecord };
-export type Suspended = { kind: "suspended"; durablePromiseId: string };
-export type Failure = { kind: "failure"; task: Task };
-export type PlatformError = { kind: "platformError"; cause: any; msg: string };
-export type CompResult = Completed | Suspended | Failure | PlatformError;
+export type Callback<T> = {
+  (err: false, res: T): void;
+  (err: true, res?: undefined): void;
+};
+
+export type Task = UnclaimedTask | ClaimedTask;
 
 export type ClaimedTask = {
   kind: "claimed";
@@ -36,14 +37,14 @@ export type UnclaimedTask = {
   rootPromiseId: string;
 };
 
-export type Task = UnclaimedTask | ClaimedTask;
-
 // Return type of a function or a generator
 export type Return<T> = T extends (...args: any[]) => Generator<infer __, infer R, infer _>
   ? R // Return type of generator
   : T extends (...args: any[]) => infer R
     ? Awaited<R> // Return type of regular function
     : never;
+
+export type Result<T> = Ok<T> | Ko;
 
 type Ok<T> = {
   success: true;
@@ -54,8 +55,6 @@ type Ko = {
   success: false;
   error: any;
 };
-
-export type Result<T> = Ok<T> | Ko;
 
 // Expression
 export type InternalExpr<T> = InternalAsyncL | InternalAsyncR | InternalAwait<T> | InternalReturn<T>;

--- a/tests/nursery.test.ts
+++ b/tests/nursery.test.ts
@@ -1,0 +1,130 @@
+import { Nursery } from "../src/nursery";
+
+describe("Nursery", () => {
+  test("nursery function executed only until done", async () => {
+    const signal = Promise.withResolvers();
+
+    let n = 0;
+    let h = 0;
+    new Nursery<any, number>(
+      (nursery) => {
+        if (n === 3) {
+          return nursery.done(null, n);
+        }
+
+        // bump n
+        n++;
+
+        // create holds, once done is called the nursery function will
+        // not be called again
+        for (let i = 0; i < 5; i++) {
+          nursery.hold((next) => {
+            h++;
+            next();
+          });
+        }
+
+        nursery.cont();
+      },
+      (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(3);
+        signal.resolve(true);
+      },
+    );
+
+    await signal.promise;
+    expect(n).toBe(3); // 0, 1, 2, 3
+    expect(h).toBe(15); // 5 * 3
+  });
+
+  test("nursery function executed once per hold release", async () => {
+    const signal = Promise.withResolvers();
+    const promises = [Promise.withResolvers(), Promise.withResolvers(), Promise.withResolvers()];
+
+    let n = 0;
+    new Nursery<any, boolean>(
+      (nursery) => {
+        // on first execution hold on three promises
+        if (n === 0) {
+          for (const { promise } of promises) {
+            nursery.hold((next) => promise.then(next));
+          }
+        }
+
+        // bump n
+        n++;
+
+        // the nusery function will be executed 4 times:
+        // - once on init
+        // - once after each hold is released (3 total)
+        if (n === 4) {
+          return nursery.done(null, true);
+        }
+
+        // continue so more can happen
+        nursery.cont();
+      },
+      (err, res) => {
+        expect(err).toBeNull();
+        expect(res).toBe(true);
+        signal.resolve(true);
+      },
+    );
+
+    // init: 1
+    expect(n).toBe(1);
+
+    // first hold released: 2
+    promises[0].resolve(true);
+    await eventLoopTick();
+    expect(n).toBe(2);
+
+    // second hold released: 3
+    promises[1].resolve(true);
+    await eventLoopTick();
+    expect(n).toBe(3);
+
+    // third hold released: 4
+    promises[2].resolve(true);
+    await eventLoopTick();
+    expect(n).toBe(4);
+
+    await signal.promise;
+  });
+
+  test("all collects all results", async () => {
+    new Nursery<any, number[]>(
+      (nursery) =>
+        nursery.all<number, number, any>(
+          [1, 2, 3],
+          (n, c) => c(undefined, n + 1),
+          (err, res) => nursery.done(err, res),
+        ),
+      (err, res) => {
+        expect(err).toBeUndefined();
+        expect(res).toEqual([2, 3, 4]);
+      },
+    );
+  });
+
+  test("all short circuits on first error", async () => {
+    new Nursery<any, number[]>(
+      (nursery) =>
+        nursery.all<number, number, any>(
+          [1, 2, 3],
+          (n, c) => c(true),
+          (err, res) => nursery.done(err, res),
+        ),
+      (err, res) => {
+        expect(err).toBe(true);
+      },
+    );
+  });
+});
+
+async function eventLoopTick() {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}


### PR DESCRIPTION
The nursery formalizes the control flow logic of the computation and separates it (as much as possible from the business logic. All code paths inside result in a call to either:
- `nursery.cont`: the nursery is not done, but is no longer actively executing
- `nursery.done`: the nursery is done, the provided callback will be called

Additionally this PR makes the following changes:
- simplifies type naming for core types (Request, Response, Message)
- adds type annotation to network `recv` function
- moves optional `onMessage` property to a subscription model
- replace `CompResult` with simplified `Status` (no longer expresses platform errors)
- propagate platform errors up callback chain (only a boolean is returned, TODO: errors will be logged at error site)