### PR TITLE
Use ReponseFor in network interface

### DIFF
--- a/dev/network.ts
+++ b/dev/network.ts
@@ -1,5 +1,6 @@
 import { Server } from "./server";
 
+import type { Callback } from "types";
 import type { Message, Network, Request, ResponseFor } from "../src/network/network";
 import * as util from "../src/util";
 
@@ -20,7 +21,7 @@ export class LocalNetwork implements Network {
     this.timeoutId = undefined;
   }
 
-  send<T extends Request>(req: Request, callback: (err: boolean, res?: ResponseFor<T>) => void): void {
+  send<T extends Request>(req: Request, callback: Callback<ResponseFor<T>>): void {
     setTimeout(() => {
       try {
         const res = this.server.process(req, Date.now());

--- a/sim/src/worker.ts
+++ b/sim/src/worker.ts
@@ -1,6 +1,7 @@
 import { NoHeartbeat } from "../../src/heartbeat";
-import type { Network, Message as NetworkMessage, Request, Response } from "../../src/network/network";
+import type { Network, Message as NetworkMessage, Request, Response, ResponseFor } from "../../src/network/network";
 import { ResonateInner } from "../../src/resonate-inner";
+import * as util from "../../src/util";
 import { type Address, Message, Process, type Random, anycast, unicast } from "./simulator";
 
 interface DeliveryOptions {
@@ -14,7 +15,7 @@ class SimulatedNetwork implements Network {
   private prng: Random;
   private deliveryOptions: Required<DeliveryOptions>;
   private buffer: Message<Request>[] = [];
-  private callbacks: Record<number, { callback: (err: boolean, res: Response) => void; timeout: number }> = {};
+  private callbacks: Record<number, { callback: (err: boolean, res?: Response) => void; timeout: number }> = {};
   private subscriptions: ((msg: NetworkMessage) => void)[] = [];
 
   constructor(
@@ -27,11 +28,16 @@ class SimulatedNetwork implements Network {
     this.deliveryOptions = { charFlipProb };
   }
 
-  send(request: Request, callback: (err: boolean, res: Response) => void): void {
-    const message = new Message<Request>(this.source, this.target, request, {
+  send<T extends Request>(req: T, cb: (err: boolean, res?: ResponseFor<T>) => void): void {
+    const message = new Message<Request>(this.source, this.target, req, {
       requ: true,
       correlationId: this.correlationId++,
     });
+
+    const callback = (err: boolean, res?: Response) => {
+      util.assert(err || (res !== undefined && res.kind === req.kind), "res kind must match req kind");
+      cb(err, res as ResponseFor<T>);
+    };
 
     this.callbacks[message.head!.correlationId] = { callback, timeout: this.currentTime + 5000 };
     this.buffer.push(message);
@@ -57,11 +63,7 @@ class SimulatedNetwork implements Network {
       const cb = this.callbacks[key];
       const hasTimedOut = cb.timeout < this.currentTime;
       if (hasTimedOut) {
-        cb.callback(true, {
-          kind: "error",
-          code: "invalid_request",
-          message: "timedout",
-        });
+        cb.callback(true);
         delete this.callbacks[key];
       }
     }

--- a/sim/src/worker.ts
+++ b/sim/src/worker.ts
@@ -1,3 +1,4 @@
+import type { Callback } from "types";
 import { NoHeartbeat } from "../../src/heartbeat";
 import type { Network, Message as NetworkMessage, Request, Response, ResponseFor } from "../../src/network/network";
 import { ResonateInner } from "../../src/resonate-inner";
@@ -15,7 +16,7 @@ class SimulatedNetwork implements Network {
   private prng: Random;
   private deliveryOptions: Required<DeliveryOptions>;
   private buffer: Message<Request>[] = [];
-  private callbacks: Record<number, { callback: (err: boolean, res?: Response) => void; timeout: number }> = {};
+  private callbacks: Record<number, { callback: Callback<Response>; timeout: number }> = {};
   private subscriptions: ((msg: NetworkMessage) => void)[] = [];
 
   constructor(

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -75,7 +75,7 @@ export class Computation {
             if (err) return done(true);
             util.assertDefined(res);
 
-            if (res.kind === "claimedtask") {
+            if (res.kind === "claimTask") {
               const { root, leaf } = res.message.promises;
               util.assertDefined(root);
 
@@ -118,7 +118,7 @@ export class Computation {
     this.handler.updateCache(task.rootPromise);
 
     // start heartbeat
-    this.heartbeat.startHeartbeat(this.ttl / 2);
+    this.heartbeat.start(this.ttl / 2);
 
     this.nurseries.set(
       task.rootPromise.id,

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -75,16 +75,14 @@ export class Computation {
             if (err) return done(true);
             util.assertDefined(res);
 
-            if (res.kind === "claimTask") {
-              const { root, leaf } = res.message.promises;
-              util.assertDefined(root);
+            const { root, leaf } = res.message.promises;
+            util.assertDefined(root);
 
-              if (leaf) {
-                this.handler.updateCache(leaf.data);
-              }
-
-              this.processClaimed({ ...task, kind: "claimed", rootPromise: root.data }, done);
+            if (leaf) {
+              this.handler.updateCache(leaf.data);
             }
+
+            this.processClaimed({ ...task, kind: "claimed", rootPromise: root.data }, done);
           },
         );
         break;

--- a/src/heartbeat.ts
+++ b/src/heartbeat.ts
@@ -1,8 +1,9 @@
 import type { Network } from "./network/network";
+import * as util from "./util";
 
 export interface Heartbeat {
-  startHeartbeat(delay: number): void;
-  stopHeartbeat(): void;
+  start(delay: number): void;
+  stop(): void;
 }
 
 export class AsyncHeartbeat implements Heartbeat {
@@ -16,7 +17,7 @@ export class AsyncHeartbeat implements Heartbeat {
     this.pid = pid;
   }
 
-  startHeartbeat(delay: number): void {
+  start(delay: number): void {
     this.counter++;
     if (!this.intervalId) {
       this.heartbeat(delay);
@@ -31,12 +32,13 @@ export class AsyncHeartbeat implements Heartbeat {
             kind: "heartbeatTasks",
             processId: this.pid,
           },
-          (_timeout, response) => {
-            if (response.kind === "heartbeatTasks" && response.tasksAffected === 0) {
+          (err, res) => {
+            if (err) return;
+            util.assertDefined(res);
+
+            if (res.tasksAffected === 0) {
               this.clearIntervalIfMatch(intervalId, counter);
-              return;
             }
-            // Ignore any errors and keep heartbeating
           },
         );
       },
@@ -46,7 +48,7 @@ export class AsyncHeartbeat implements Heartbeat {
     );
   }
 
-  stopHeartbeat(): void {
+  stop(): void {
     this.clearIntervalIfMatch(this.intervalId, this.counter);
   }
 
@@ -59,6 +61,6 @@ export class AsyncHeartbeat implements Heartbeat {
 }
 
 export class NoHeartbeat implements Heartbeat {
-  startHeartbeat(delay: number): void {}
-  stopHeartbeat(): void {}
+  start(delay: number): void {}
+  stop(): void {}
 }

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -262,12 +262,6 @@ export type HeartbeatTasksRes = {
   tasksAffected: number;
 };
 
-export type ErrorRes = {
-  kind: "error";
-  code: "invalid_request" | "forbidden" | "not_found" | "conflict";
-  message: string;
-};
-
 // Message
 
 export type Message =

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -1,3 +1,7 @@
+// Records
+
+import type { Callback } from "types";
+
 export interface DurablePromiseRecord {
   id: string;
   state: "pending" | "resolved" | "rejected" | "rejected_canceled" | "rejected_timedout";
@@ -43,21 +47,23 @@ export interface CallbackRecord {
   createdOn?: number;
 }
 
-export interface Mesg {
-  kind: "invoke" | "resume";
-  promises: {
-    root?: {
-      id: string;
-      data: DurablePromiseRecord;
-    };
-    leaf?: {
-      id: string;
-      data: DurablePromiseRecord;
-    };
-  };
-}
+// Request
 
-// Request message types
+export type Request =
+  | CreatePromiseReq
+  | CreatePromiseAndTaskReq
+  | ReadPromiseReq
+  | CompletePromiseReq
+  | CreateCallbackReq
+  | CreateSubscriptionReq
+  | CreateScheduleReq
+  | ReadScheduleReq
+  | DeleteScheduleReq
+  | ClaimTaskReq
+  | CompleteTaskReq
+  | DropTaskReq
+  | HeartbeatTasksReq;
+
 export type CreatePromiseReq = {
   kind: "createPromise";
   id: string;
@@ -161,23 +167,23 @@ export type HeartbeatTasksReq = {
   processId: string;
 };
 
-// Union of all request types
-export type Request =
-  | CreatePromiseReq
-  | CreatePromiseAndTaskReq
-  | ReadPromiseReq
-  | CompletePromiseReq
-  | CreateCallbackReq
-  | CreateSubscriptionReq
-  | CreateScheduleReq
-  | ReadScheduleReq
-  | DeleteScheduleReq
-  | ClaimTaskReq
-  | CompleteTaskReq
-  | DropTaskReq
-  | HeartbeatTasksReq;
+// Response
 
-// Response message types
+export type Response =
+  | CreatePromiseRes
+  | CreatePromiseAndTaskRes
+  | ReadPromiseRes
+  | CompletePromiseRes
+  | CreateCallbackRes
+  | CreateSubscriptionRes
+  | CreateScheduleRes
+  | ReadScheduleRes
+  | DeleteScheduleRes
+  | ClaimTaskRes
+  | CompleteTaskRes
+  | DropTaskRes
+  | HeartbeatTasksRes;
+
 export type CreatePromiseRes = {
   kind: "createPromise";
   promise: DurablePromiseRecord;
@@ -226,17 +232,29 @@ export type DeleteScheduleRes = {
 };
 
 export type ClaimTaskRes = {
-  kind: "claimedtask";
-  message: Mesg;
+  kind: "claimTask";
+  message: {
+    kind: "invoke" | "resume";
+    promises: {
+      root?: {
+        id: string;
+        data: DurablePromiseRecord;
+      };
+      leaf?: {
+        id: string;
+        data: DurablePromiseRecord;
+      };
+    };
+  };
 };
 
 export type CompleteTaskRes = {
-  kind: "completedtask";
+  kind: "completeTask";
   task: TaskRecord;
 };
 
 export type DropTaskRes = {
-  kind: "droppedtask";
+  kind: "dropTask";
 };
 
 export type HeartbeatTasksRes = {
@@ -244,36 +262,24 @@ export type HeartbeatTasksRes = {
   tasksAffected: number;
 };
 
-// Error response types
 export type ErrorRes = {
   kind: "error";
   code: "invalid_request" | "forbidden" | "not_found" | "conflict";
   message: string;
 };
 
-// Union of all response types
-export type Response =
-  | CreatePromiseRes
-  | CreatePromiseAndTaskRes
-  | ReadPromiseRes
-  | CompletePromiseRes
-  | CreateCallbackRes
-  | CreateSubscriptionRes
-  | CreateScheduleRes
-  | ReadScheduleRes
-  | DeleteScheduleRes
-  | ClaimTaskRes
-  | CompleteTaskRes
-  | DropTaskRes
-  | HeartbeatTasksRes
-  | ErrorRes;
+// Message
 
 export type Message =
   | { type: "invoke" | "resume"; task: TaskRecord }
   | { type: "notify"; promise: DurablePromiseRecord };
 
+// Network
+
+export type ResponseFor<T extends Request> = Extract<Response, { kind: T["kind"] }>;
+
 export interface Network {
-  send(req: Request, callback: (err: boolean, res: Response) => void): void;
+  send<T extends Request>(req: T, callback: Callback<ResponseFor<T>>): void;
   recv(msg: Message): void;
   stop(): void;
   subscribe(callback: (msg: Message) => void): void;

--- a/src/network/remote.ts
+++ b/src/network/remote.ts
@@ -21,7 +21,6 @@ import type {
   DropTaskReq,
   DropTaskRes,
   DurablePromiseRecord,
-  ErrorRes,
   HeartbeatTasksReq,
   HeartbeatTasksRes,
   Message,
@@ -38,6 +37,7 @@ import type {
 } from "./network"; // Assuming types are in a separate file
 
 import { EventSource } from "eventsource";
+import type { Callback } from "types";
 import * as util from "../util";
 
 // API Value format from OpenAPI spec
@@ -244,7 +244,7 @@ export class HttpNetwork implements Network {
     this.eventSource.addEventListener("message", (event) => this._recv(event));
   }
 
-  send<T extends Request>(req: T, callback: (timeout: boolean, response?: ResponseFor<T>) => void): void {
+  send<T extends Request>(req: T, callback: Callback<ResponseFor<T>>): void {
     this.handleRequest(req).then(
       (res) => {
         util.assert(res.kind === req.kind, "res kind must match req kind");
@@ -686,13 +686,5 @@ export class HttpNetwork implements Network {
       default:
         throw new Error(`Unknown API state: ${apiState}`);
     }
-  }
-
-  private createErrorResponse(code: ErrorRes["code"], message: string): ErrorRes {
-    return {
-      kind: "error",
-      code,
-      message,
-    };
   }
 }

--- a/src/promises.ts
+++ b/src/promises.ts
@@ -1,7 +1,6 @@
 import { LocalNetwork } from "../dev/network";
 import type { CallbackRecord, DurablePromiseRecord, Network, TaskRecord } from "./network/network";
 
-import * as util from "./util";
 export class Promises {
   private network: Network;
   constructor(network: Network = new LocalNetwork()) {
@@ -10,21 +9,14 @@ export class Promises {
 
   get(id: string): Promise<DurablePromiseRecord> {
     return new Promise((resolve, reject) => {
-      this.network.send({ kind: "readPromise", id: id }, (timeout, response) => {
-        if (timeout) {
-          util.assert(response.kind === "error");
-          throw new Error("not implemented");
+      this.network.send({ kind: "readPromise", id: id }, (err, res) => {
+        if (err) {
+          // TODO: reject with more information
+          reject(Error("not implemented"));
+          return;
         }
 
-        if (response.kind === "error") {
-          util.assert(!timeout);
-          reject(response);
-        } else {
-          if (response.kind !== "readPromise") {
-            throw new Error("unexpected response");
-          }
-          resolve(response.promise);
-        }
+        resolve(res!.promise);
       });
     });
   }
@@ -48,21 +40,14 @@ export class Promises {
           iKey: iKey,
           strict: strict,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "createPromise") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.promise);
-          }
+          resolve(res!.promise);
         },
       );
     });
@@ -95,21 +80,14 @@ export class Promises {
           iKey: iKey,
           strict: strict,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "createPromiseAndTask") {
-              throw new Error("unexpected response");
-            }
-            resolve(response);
-          }
+          resolve({ promise: res!.promise, task: res!.task });
         },
       );
     });
@@ -131,21 +109,14 @@ export class Promises {
           iKey: iKey,
           strict: strict,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "completePromise") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.promise);
-          }
+          resolve(res!.promise);
         },
       );
     });
@@ -166,21 +137,14 @@ export class Promises {
           iKey: iKey,
           strict: strict,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "completePromise") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.promise);
-          }
+          resolve(res!.promise);
         },
       );
     });
@@ -201,21 +165,14 @@ export class Promises {
           iKey: iKey,
           strict: strict,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "completePromise") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.promise);
-          }
+          resolve(res!.promise);
         },
       );
     });
@@ -239,21 +196,14 @@ export class Promises {
           timeout: timeout,
           recv: recv,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "createCallback") {
-              throw new Error("unexpected response");
-            }
-            resolve({ promise: response.promise, callback: response.callback });
-          }
+          resolve({ promise: res!.promise, callback: res!.callback });
         },
       );
     });
@@ -268,21 +218,14 @@ export class Promises {
     callback: CallbackRecord | undefined;
   }> {
     return new Promise((resolve, reject) => {
-      this.network.send({ kind: "createSubscription", id: id, timeout: timeout, recv: recv }, (timeout, response) => {
-        if (timeout) {
-          util.assert(response.kind === "error");
-          throw new Error("not implemented");
+      this.network.send({ kind: "createSubscription", id: id, timeout: timeout, recv: recv }, (err, res) => {
+        if (err) {
+          // TODO: reject with more information
+          reject(Error("not implemented"));
+          return;
         }
 
-        if (response.kind === "error") {
-          util.assert(!timeout);
-          reject(response);
-        } else {
-          if (response.kind !== "createSubscription") {
-            throw new Error("unexpected response");
-          }
-          resolve({ promise: response.promise, callback: response.callback });
-        }
+        resolve({ promise: res!.promise, callback: res!.callback });
       });
     });
   }

--- a/src/resonate-inner.ts
+++ b/src/resonate-inner.ts
@@ -107,6 +107,6 @@ export class ResonateInner {
 
   public stop() {
     this.network.stop();
-    this.heartbeat.stopHeartbeat();
+    this.heartbeat.stop();
   }
 }

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -1,12 +1,6 @@
 import { LocalNetwork } from "../dev/network";
 import { AsyncHeartbeat } from "./heartbeat";
-import type {
-  CreatePromiseAndTaskRes,
-  CreatePromiseRes,
-  CreateSubscriptionRes,
-  DurablePromiseRecord,
-  Network,
-} from "./network/network";
+import type { DurablePromiseRecord, Network } from "./network/network";
 import { HttpNetwork } from "./network/remote";
 import { ResonateInner } from "./resonate-inner";
 import { type Func, type Options, type ParamsWithOptions, RESONATE_OPTIONS, type Return } from "./types";
@@ -144,14 +138,10 @@ export class Resonate {
           iKey: id,
           strict: false,
         },
-        (timeout, response) => {
-          const res = response as CreatePromiseAndTaskRes;
-
-          if (timeout) {
-            // TODO(avillega): Handle platform level error
-            console.error("Platform error");
-            return;
-          }
+        (err, res) => {
+          // TODO(avillega): Handle platform level error
+          if (err) return;
+          util.assertDefined(res);
 
           // create and resolve a handle now that the durable promise
           // has been created
@@ -228,14 +218,10 @@ export class Resonate {
           iKey: id,
           strict: false,
         },
-        (timeout, response) => {
-          const res = response as CreatePromiseRes;
-
-          if (timeout) {
-            // TODO(avillega): Handle platform level error
-            console.error("Platform error");
-            return;
-          }
+        (err, res) => {
+          // TODO(avillega): Handle platform level error
+          if (err) return;
+          util.assertDefined(res);
 
           // create and resolve a handle now that the durable promise
           // has been created
@@ -272,14 +258,10 @@ export class Resonate {
         timeout: 24 * util.HOUR + Date.now(), // TODO(avillega): use option timeout or 24h. Check the  usage of Date here, seems fine
         recv: `poll://uni@${this.group}/${this.pid}`,
       },
-      (timeout, response) => {
-        const res = response as CreateSubscriptionRes;
-
-        if (timeout) {
-          // TODO(avillega): Handle platform level error
-          console.error("Platform error");
-          return;
-        }
+      (err, res) => {
+        // TODO(avillega): Handle platform level error
+        if (err) return;
+        util.assertDefined(res);
 
         // once again check if the promise is complete and early exit
         if (this.complete(res.promise, resolve, reject)) {

--- a/src/schedules.ts
+++ b/src/schedules.ts
@@ -1,8 +1,6 @@
 import { LocalNetwork } from "../dev/network";
 import type { Network, ScheduleRecord } from "./network/network";
 
-import * as util from "./util";
-
 export class Schedules {
   private network: Network;
 
@@ -17,21 +15,14 @@ export class Schedules {
           kind: "readSchedule",
           id: id,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "readSchedule") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.schedule);
-          }
+          resolve(res!.schedule);
         },
       );
     });
@@ -62,21 +53,14 @@ export class Schedules {
           promiseTags: promiseTags,
           iKey: iKey,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "createSchedule") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.schedule);
-          }
+          resolve(res!.schedule);
         },
       );
     });
@@ -89,21 +73,14 @@ export class Schedules {
           kind: "deleteSchedule",
           id: id,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "deleteSchedule") {
-              throw new Error("unexpected response");
-            }
-            resolve();
-          }
+          resolve();
         },
       );
     });

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,7 +1,5 @@
 import { LocalNetwork } from "../dev/network";
-import type { Mesg, Network, TaskRecord } from "./network/network";
-
-import * as util from "./util";
+import type { ClaimTaskRes, Network, TaskRecord } from "./network/network";
 
 export class Tasks {
   private network: Network;
@@ -10,7 +8,7 @@ export class Tasks {
     this.network = network;
   }
 
-  claim(id: string, counter: number, processId: string, ttl: number): Promise<Mesg> {
+  claim(id: string, counter: number, processId: string, ttl: number): Promise<ClaimTaskRes["message"]> {
     return new Promise((resolve, reject) => {
       this.network.send(
         {
@@ -20,21 +18,14 @@ export class Tasks {
           processId: processId,
           ttl: ttl,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "claimedtask") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.message);
-          }
+          resolve(res!.message);
         },
       );
     });
@@ -48,21 +39,14 @@ export class Tasks {
           id: id,
           counter: counter,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "completedtask") {
-              throw new Error("unexpected response");
-            }
-            resolve(response.task);
-          }
+          resolve(res!.task);
         },
       );
     });
@@ -75,22 +59,14 @@ export class Tasks {
           kind: "heartbeatTasks",
           processId: processId,
         },
-        (timeout, response) => {
-          if (timeout) {
-            util.assert(response.kind === "error");
-            throw new Error("not implemented");
+        (err, res) => {
+          if (err) {
+            // TODO: reject with more information
+            reject(Error("not implemented"));
+            return;
           }
 
-          if (response.kind === "error") {
-            util.assert(!timeout);
-            reject(response);
-          } else {
-            if (response.kind !== "heartbeatTasks") {
-              throw new Error("unexpected response");
-            }
-
-            resolve(response.tasksAffected);
-          }
+          resolve(res!.tasksAffected);
         },
       );
     });

--- a/tests/computation.test.ts
+++ b/tests/computation.test.ts
@@ -2,7 +2,7 @@ import { LocalNetwork } from "../dev/network";
 import { Computation, type Status } from "../src/computation";
 import type { Context } from "../src/context";
 import { NoHeartbeat } from "../src/heartbeat";
-import type { CreatePromiseAndTaskRes, DurablePromiseRecord, Network, TaskRecord } from "../src/network/network";
+import type { DurablePromiseRecord, Network, TaskRecord } from "../src/network/network";
 import type { Processor } from "../src/processor/processor";
 import { Registry } from "../src/registry";
 import type { ClaimedTask, Result } from "../src/types";
@@ -34,9 +34,8 @@ async function createPromiseAndTask(
         iKey: id,
         strict: false,
       },
-      (_timeout, res) => {
-        const { promise, task } = res as CreatePromiseAndTaskRes;
-        resolve({ promise, task: task! });
+      (_err, res) => {
+        resolve({ promise: res!.promise, task: res!.task! });
       },
     );
   });

--- a/tests/store.promises.test.ts
+++ b/tests/store.promises.test.ts
@@ -42,98 +42,90 @@ describe("State Transition Tests", () => {
 
   test("Test Case 4: transitions from Init to Init via Resolve", async () => {
     const promises = new Promises();
-    await expect(promises.resolve("id4", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id4", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 5: transitions from Init to Init via Resolve", async () => {
     const promises = new Promises();
-    await expect(promises.resolve("id5", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id5", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 6: transitions from Init to Init via Resolve", async () => {
     const promises = new Promises();
-    await expect(promises.resolve("id6", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id6", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 7: transitions from Init to Init via Resolve", async () => {
     const promises = new Promises();
-    await expect(promises.resolve("id7", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id7", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 8: transitions from Init to Init via Reject", async () => {
     const promises = new Promises();
-    await expect(promises.reject("id8", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id8", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 9: transitions from Init to Init via Reject", async () => {
     const promises = new Promises();
-    await expect(promises.reject("id9", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id9", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 10: transitions from Init to Init via Reject", async () => {
     const promises = new Promises();
-    await expect(promises.reject("id10", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id10", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 11: transitions from Init to Init via Reject", async () => {
     const promises = new Promises();
-    await expect(promises.reject("id11", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id11", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 12: transitions from Init to Init via Cancel", async () => {
     const promises = new Promises();
-    await expect(promises.cancel("id12", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id12", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 13: transitions from Init to Init via Cancel", async () => {
     const promises = new Promises();
-    await expect(promises.cancel("id13", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id13", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 14: transitions from Init to Init via Cancel", async () => {
     const promises = new Promises();
-    await expect(promises.cancel("id14", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id14", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 15: transitions from Init to Init via Cancel", async () => {
     const promises = new Promises();
-    await expect(promises.cancel("id15", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id15", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 16: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id16", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
 
-    await expect(
-      promises.create("id16", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id16", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 17: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id17", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
 
-    await expect(
-      promises.create("id17", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id17", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 18: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id18", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
 
-    await expect(promises.create("id18", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id18", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 19: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id19", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
 
-    await expect(promises.create("id19", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id19", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 20: transitions from Pending to Resolved via Resolve", async () => {
@@ -284,18 +276,14 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id32", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
 
-    await expect(
-      promises.create("id32", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id32", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 33: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id33", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
 
-    await expect(
-      promises.create("id33", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id33", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 34: transitions from Pending to Pending via Create", async () => {
@@ -326,18 +314,14 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id36", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
 
-    await expect(promises.create("id36", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id36", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 37: transitions from Pending to Pending via Create", async () => {
     const promises = new Promises();
     await promises.create("id37", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
 
-    await expect(promises.create("id37", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id37", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 38: transitions from Pending to Resolved via Resolve", async () => {
@@ -489,9 +473,7 @@ describe("State Transition Tests", () => {
     await promises.create("id50", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id50", undefined, false, undefined);
 
-    await expect(
-      promises.create("id50", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id50", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 51: transitions from Resolved to Resolved via Create", async () => {
@@ -499,9 +481,7 @@ describe("State Transition Tests", () => {
     await promises.create("id51", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id51", undefined, false, undefined);
 
-    await expect(
-      promises.create("id51", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id51", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 52: transitions from Resolved to Resolved via Create", async () => {
@@ -509,9 +489,7 @@ describe("State Transition Tests", () => {
     await promises.create("id52", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id52", undefined, false, undefined);
 
-    await expect(promises.create("id52", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id52", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 53: transitions from Resolved to Resolved via Create", async () => {
@@ -519,9 +497,7 @@ describe("State Transition Tests", () => {
     await promises.create("id53", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id53", undefined, false, undefined);
 
-    await expect(promises.create("id53", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id53", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 54: transitions from Resolved to Resolved via Resolve", async () => {
@@ -529,7 +505,7 @@ describe("State Transition Tests", () => {
     await promises.create("id54", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id54", undefined, false, undefined);
 
-    await expect(promises.resolve("id54", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id54", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 55: transitions from Resolved to Resolved via Resolve", async () => {
@@ -537,7 +513,7 @@ describe("State Transition Tests", () => {
     await promises.create("id55", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id55", undefined, false, undefined);
 
-    await expect(promises.resolve("id55", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id55", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 56: transitions from Resolved to Resolved via Resolve", async () => {
@@ -545,7 +521,7 @@ describe("State Transition Tests", () => {
     await promises.create("id56", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id56", undefined, false, undefined);
 
-    await expect(promises.resolve("id56", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id56", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 57: transitions from Resolved to Resolved via Resolve", async () => {
@@ -553,7 +529,7 @@ describe("State Transition Tests", () => {
     await promises.create("id57", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id57", undefined, false, undefined);
 
-    await expect(promises.resolve("id57", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id57", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 58: transitions from Resolved to Resolved via Reject", async () => {
@@ -561,7 +537,7 @@ describe("State Transition Tests", () => {
     await promises.create("id58", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id58", undefined, false, undefined);
 
-    await expect(promises.reject("id58", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id58", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 59: transitions from Resolved to Resolved via Reject", async () => {
@@ -569,7 +545,7 @@ describe("State Transition Tests", () => {
     await promises.create("id59", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id59", undefined, false, undefined);
 
-    await expect(promises.reject("id59", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id59", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 60: transitions from Resolved to Resolved via Reject", async () => {
@@ -577,7 +553,7 @@ describe("State Transition Tests", () => {
     await promises.create("id60", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id60", undefined, false, undefined);
 
-    await expect(promises.reject("id60", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id60", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 61: transitions from Resolved to Resolved via Reject", async () => {
@@ -585,7 +561,7 @@ describe("State Transition Tests", () => {
     await promises.create("id61", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id61", undefined, false, undefined);
 
-    await expect(promises.reject("id61", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id61", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 62: transitions from Resolved to Resolved via Cancel", async () => {
@@ -593,7 +569,7 @@ describe("State Transition Tests", () => {
     await promises.create("id62", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id62", undefined, false, undefined);
 
-    await expect(promises.cancel("id62", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id62", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 63: transitions from Resolved to Resolved via Cancel", async () => {
@@ -601,7 +577,7 @@ describe("State Transition Tests", () => {
     await promises.create("id63", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id63", undefined, false, undefined);
 
-    await expect(promises.cancel("id63", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id63", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 64: transitions from Resolved to Resolved via Cancel", async () => {
@@ -609,7 +585,7 @@ describe("State Transition Tests", () => {
     await promises.create("id64", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id64", undefined, false, undefined);
 
-    await expect(promises.cancel("id64", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id64", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 65: transitions from Resolved to Resolved via Cancel", async () => {
@@ -617,7 +593,7 @@ describe("State Transition Tests", () => {
     await promises.create("id65", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id65", undefined, false, undefined);
 
-    await expect(promises.cancel("id65", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id65", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 66: transitions from Resolved to Resolved via Create", async () => {
@@ -625,9 +601,7 @@ describe("State Transition Tests", () => {
     await promises.create("id66", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id66", "iku", false, undefined);
 
-    await expect(
-      promises.create("id66", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id66", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 67: transitions from Resolved to Resolved via Create", async () => {
@@ -635,9 +609,7 @@ describe("State Transition Tests", () => {
     await promises.create("id67", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id67", "iku", false, undefined);
 
-    await expect(
-      promises.create("id67", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id67", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 68: transitions from Resolved to Resolved via Create", async () => {
@@ -645,9 +617,7 @@ describe("State Transition Tests", () => {
     await promises.create("id68", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id68", "iku", false, undefined);
 
-    await expect(promises.create("id68", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id68", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 69: transitions from Resolved to Resolved via Create", async () => {
@@ -655,9 +625,7 @@ describe("State Transition Tests", () => {
     await promises.create("id69", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id69", "iku", false, undefined);
 
-    await expect(promises.create("id69", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id69", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 70: transitions from Resolved to Resolved via Resolve", async () => {
@@ -665,7 +633,7 @@ describe("State Transition Tests", () => {
     await promises.create("id70", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id70", "iku", false, undefined);
 
-    await expect(promises.resolve("id70", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id70", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 71: transitions from Resolved to Resolved via Resolve", async () => {
@@ -673,7 +641,7 @@ describe("State Transition Tests", () => {
     await promises.create("id71", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id71", "iku", false, undefined);
 
-    await expect(promises.resolve("id71", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id71", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 72: transitions from Resolved to Resolved via Resolve", async () => {
@@ -707,7 +675,7 @@ describe("State Transition Tests", () => {
     await promises.create("id74", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id74", "iku", false, undefined);
 
-    await expect(promises.resolve("id74", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id74", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 75: transitions from Resolved to Resolved via Resolve", async () => {
@@ -715,7 +683,7 @@ describe("State Transition Tests", () => {
     await promises.create("id75", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id75", "iku", false, undefined);
 
-    await expect(promises.resolve("id75", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id75", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 76: transitions from Resolved to Resolved via Reject", async () => {
@@ -723,7 +691,7 @@ describe("State Transition Tests", () => {
     await promises.create("id76", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id76", "iku", false, undefined);
 
-    await expect(promises.reject("id76", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id76", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 77: transitions from Resolved to Resolved via Reject", async () => {
@@ -731,7 +699,7 @@ describe("State Transition Tests", () => {
     await promises.create("id77", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id77", "iku", false, undefined);
 
-    await expect(promises.reject("id77", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id77", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 78: transitions from Resolved to Resolved via Reject", async () => {
@@ -739,7 +707,7 @@ describe("State Transition Tests", () => {
     await promises.create("id78", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id78", "iku", false, undefined);
 
-    await expect(promises.reject("id78", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id78", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 79: transitions from Resolved to Resolved via Reject", async () => {
@@ -760,7 +728,7 @@ describe("State Transition Tests", () => {
     await promises.create("id80", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id80", "iku", false, undefined);
 
-    await expect(promises.reject("id80", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id80", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 81: transitions from Resolved to Resolved via Reject", async () => {
@@ -768,7 +736,7 @@ describe("State Transition Tests", () => {
     await promises.create("id81", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id81", "iku", false, undefined);
 
-    await expect(promises.reject("id81", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id81", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 82: transitions from Resolved to Resolved via Cancel", async () => {
@@ -776,7 +744,7 @@ describe("State Transition Tests", () => {
     await promises.create("id82", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id82", "iku", false, undefined);
 
-    await expect(promises.cancel("id82", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id82", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 83: transitions from Resolved to Resolved via Cancel", async () => {
@@ -784,7 +752,7 @@ describe("State Transition Tests", () => {
     await promises.create("id83", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id83", "iku", false, undefined);
 
-    await expect(promises.cancel("id83", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id83", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 84: transitions from Resolved to Resolved via Cancel", async () => {
@@ -792,7 +760,7 @@ describe("State Transition Tests", () => {
     await promises.create("id84", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id84", "iku", false, undefined);
 
-    await expect(promises.cancel("id84", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id84", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 85: transitions from Resolved to Resolved via Cancel", async () => {
@@ -813,7 +781,7 @@ describe("State Transition Tests", () => {
     await promises.create("id86", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id86", "iku", false, undefined);
 
-    await expect(promises.cancel("id86", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id86", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 87: transitions from Resolved to Resolved via Cancel", async () => {
@@ -821,7 +789,7 @@ describe("State Transition Tests", () => {
     await promises.create("id87", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.resolve("id87", "iku", false, undefined);
 
-    await expect(promises.cancel("id87", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id87", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 88: transitions from Resolved to Resolved via Create", async () => {
@@ -829,9 +797,7 @@ describe("State Transition Tests", () => {
     await promises.create("id88", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id88", undefined, false, undefined);
 
-    await expect(
-      promises.create("id88", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id88", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 89: transitions from Resolved to Resolved via Create", async () => {
@@ -839,9 +805,7 @@ describe("State Transition Tests", () => {
     await promises.create("id89", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id89", undefined, false, undefined);
 
-    await expect(
-      promises.create("id89", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id89", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 90: transitions from Resolved to Resolved via Create", async () => {
@@ -849,9 +813,7 @@ describe("State Transition Tests", () => {
     await promises.create("id90", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id90", undefined, false, undefined);
 
-    await expect(promises.create("id90", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id90", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 91: transitions from Resolved to Resolved via Create", async () => {
@@ -872,9 +834,7 @@ describe("State Transition Tests", () => {
     await promises.create("id92", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id92", undefined, false, undefined);
 
-    await expect(promises.create("id92", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id92", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 93: transitions from Resolved to Resolved via Create", async () => {
@@ -882,9 +842,7 @@ describe("State Transition Tests", () => {
     await promises.create("id93", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id93", undefined, false, undefined);
 
-    await expect(promises.create("id93", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id93", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 94: transitions from Resolved to Resolved via Resolve", async () => {
@@ -892,7 +850,7 @@ describe("State Transition Tests", () => {
     await promises.create("id94", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id94", undefined, false, undefined);
 
-    await expect(promises.resolve("id94", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id94", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 95: transitions from Resolved to Resolved via Resolve", async () => {
@@ -900,7 +858,7 @@ describe("State Transition Tests", () => {
     await promises.create("id95", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id95", undefined, false, undefined);
 
-    await expect(promises.resolve("id95", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id95", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 96: transitions from Resolved to Resolved via Resolve", async () => {
@@ -908,7 +866,7 @@ describe("State Transition Tests", () => {
     await promises.create("id96", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id96", undefined, false, undefined);
 
-    await expect(promises.resolve("id96", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id96", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 97: transitions from Resolved to Resolved via Resolve", async () => {
@@ -916,7 +874,7 @@ describe("State Transition Tests", () => {
     await promises.create("id97", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id97", undefined, false, undefined);
 
-    await expect(promises.resolve("id97", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id97", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 98: transitions from Resolved to Resolved via Reject", async () => {
@@ -924,7 +882,7 @@ describe("State Transition Tests", () => {
     await promises.create("id98", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id98", undefined, false, undefined);
 
-    await expect(promises.reject("id98", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id98", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 99: transitions from Resolved to Resolved via Reject", async () => {
@@ -932,7 +890,7 @@ describe("State Transition Tests", () => {
     await promises.create("id99", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id99", undefined, false, undefined);
 
-    await expect(promises.reject("id99", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id99", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 100: transitions from Resolved to Resolved via Reject", async () => {
@@ -940,7 +898,7 @@ describe("State Transition Tests", () => {
     await promises.create("id100", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id100", undefined, false, undefined);
 
-    await expect(promises.reject("id100", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id100", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 101: transitions from Resolved to Resolved via Reject", async () => {
@@ -948,7 +906,7 @@ describe("State Transition Tests", () => {
     await promises.create("id101", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id101", undefined, false, undefined);
 
-    await expect(promises.reject("id101", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id101", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 102: transitions from Resolved to Resolved via Cancel", async () => {
@@ -956,7 +914,7 @@ describe("State Transition Tests", () => {
     await promises.create("id102", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id102", undefined, false, undefined);
 
-    await expect(promises.cancel("id102", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id102", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 103: transitions from Resolved to Resolved via Cancel", async () => {
@@ -964,7 +922,7 @@ describe("State Transition Tests", () => {
     await promises.create("id103", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id103", undefined, false, undefined);
 
-    await expect(promises.cancel("id103", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id103", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 104: transitions from Resolved to Resolved via Cancel", async () => {
@@ -972,7 +930,7 @@ describe("State Transition Tests", () => {
     await promises.create("id104", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id104", undefined, false, undefined);
 
-    await expect(promises.cancel("id104", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id104", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 105: transitions from Resolved to Resolved via Cancel", async () => {
@@ -980,7 +938,7 @@ describe("State Transition Tests", () => {
     await promises.create("id105", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id105", undefined, false, undefined);
 
-    await expect(promises.cancel("id105", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id105", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 106: transitions from Resolved to Resolved via Create", async () => {
@@ -988,9 +946,7 @@ describe("State Transition Tests", () => {
     await promises.create("id106", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id106", "iku", false, undefined);
 
-    await expect(
-      promises.create("id106", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id106", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 107: transitions from Resolved to Resolved via Create", async () => {
@@ -998,9 +954,7 @@ describe("State Transition Tests", () => {
     await promises.create("id107", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id107", "iku", false, undefined);
 
-    await expect(
-      promises.create("id107", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id107", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 108: transitions from Resolved to Resolved via Create", async () => {
@@ -1008,9 +962,7 @@ describe("State Transition Tests", () => {
     await promises.create("id108", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id108", "iku", false, undefined);
 
-    await expect(promises.create("id108", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id108", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 109: transitions from Resolved to Resolved via Create", async () => {
@@ -1031,9 +983,7 @@ describe("State Transition Tests", () => {
     await promises.create("id110", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id110", "iku", false, undefined);
 
-    await expect(promises.create("id110", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id110", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 111: transitions from Resolved to Resolved via Create", async () => {
@@ -1041,9 +991,7 @@ describe("State Transition Tests", () => {
     await promises.create("id111", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id111", "iku", false, undefined);
 
-    await expect(promises.create("id111", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id111", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 112: transitions from Resolved to Resolved via Resolve", async () => {
@@ -1051,7 +999,7 @@ describe("State Transition Tests", () => {
     await promises.create("id112", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id112", "iku", false, undefined);
 
-    await expect(promises.resolve("id112", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id112", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 113: transitions from Resolved to Resolved via Resolve", async () => {
@@ -1059,7 +1007,7 @@ describe("State Transition Tests", () => {
     await promises.create("id113", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id113", "iku", false, undefined);
 
-    await expect(promises.resolve("id113", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id113", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 114: transitions from Resolved to Resolved via Resolve", async () => {
@@ -1093,7 +1041,7 @@ describe("State Transition Tests", () => {
     await promises.create("id116", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id116", "iku", false, undefined);
 
-    await expect(promises.resolve("id116", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id116", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 117: transitions from Resolved to Resolved via Resolve", async () => {
@@ -1101,7 +1049,7 @@ describe("State Transition Tests", () => {
     await promises.create("id117", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id117", "iku", false, undefined);
 
-    await expect(promises.resolve("id117", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id117", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 118: transitions from Resolved to Resolved via Reject", async () => {
@@ -1109,7 +1057,7 @@ describe("State Transition Tests", () => {
     await promises.create("id118", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id118", "iku", false, undefined);
 
-    await expect(promises.reject("id118", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id118", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 119: transitions from Resolved to Resolved via Reject", async () => {
@@ -1117,7 +1065,7 @@ describe("State Transition Tests", () => {
     await promises.create("id119", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id119", "iku", false, undefined);
 
-    await expect(promises.reject("id119", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id119", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 120: transitions from Resolved to Resolved via Reject", async () => {
@@ -1125,7 +1073,7 @@ describe("State Transition Tests", () => {
     await promises.create("id120", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id120", "iku", false, undefined);
 
-    await expect(promises.reject("id120", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id120", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 121: transitions from Resolved to Resolved via Reject", async () => {
@@ -1146,7 +1094,7 @@ describe("State Transition Tests", () => {
     await promises.create("id122", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id122", "iku", false, undefined);
 
-    await expect(promises.reject("id122", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id122", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 123: transitions from Resolved to Resolved via Reject", async () => {
@@ -1154,7 +1102,7 @@ describe("State Transition Tests", () => {
     await promises.create("id123", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id123", "iku", false, undefined);
 
-    await expect(promises.reject("id123", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id123", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 124: transitions from Resolved to Resolved via Cancel", async () => {
@@ -1162,7 +1110,7 @@ describe("State Transition Tests", () => {
     await promises.create("id124", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id124", "iku", false, undefined);
 
-    await expect(promises.cancel("id124", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id124", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 125: transitions from Resolved to Resolved via Cancel", async () => {
@@ -1170,7 +1118,7 @@ describe("State Transition Tests", () => {
     await promises.create("id125", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id125", "iku", false, undefined);
 
-    await expect(promises.cancel("id125", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id125", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 126: transitions from Resolved to Resolved via Cancel", async () => {
@@ -1178,7 +1126,7 @@ describe("State Transition Tests", () => {
     await promises.create("id126", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id126", "iku", false, undefined);
 
-    await expect(promises.cancel("id126", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id126", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 127: transitions from Resolved to Resolved via Cancel", async () => {
@@ -1199,7 +1147,7 @@ describe("State Transition Tests", () => {
     await promises.create("id128", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id128", "iku", false, undefined);
 
-    await expect(promises.cancel("id128", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id128", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 129: transitions from Resolved to Resolved via Cancel", async () => {
@@ -1207,7 +1155,7 @@ describe("State Transition Tests", () => {
     await promises.create("id129", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.resolve("id129", "iku", false, undefined);
 
-    await expect(promises.cancel("id129", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id129", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 130: transitions from Rejected to Rejected via Create", async () => {
@@ -1215,9 +1163,7 @@ describe("State Transition Tests", () => {
     await promises.create("id130", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id130", undefined, false, undefined);
 
-    await expect(
-      promises.create("id130", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id130", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 131: transitions from Rejected to Rejected via Create", async () => {
@@ -1225,9 +1171,7 @@ describe("State Transition Tests", () => {
     await promises.create("id131", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id131", undefined, false, undefined);
 
-    await expect(
-      promises.create("id131", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id131", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 132: transitions from Rejected to Rejected via Create", async () => {
@@ -1235,9 +1179,7 @@ describe("State Transition Tests", () => {
     await promises.create("id132", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id132", undefined, false, undefined);
 
-    await expect(promises.create("id132", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id132", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 133: transitions from Rejected to Rejected via Create", async () => {
@@ -1245,9 +1187,7 @@ describe("State Transition Tests", () => {
     await promises.create("id133", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id133", undefined, false, undefined);
 
-    await expect(promises.create("id133", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id133", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 134: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1255,7 +1195,7 @@ describe("State Transition Tests", () => {
     await promises.create("id134", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id134", undefined, false, undefined);
 
-    await expect(promises.resolve("id134", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id134", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 135: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1263,7 +1203,7 @@ describe("State Transition Tests", () => {
     await promises.create("id135", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id135", undefined, false, undefined);
 
-    await expect(promises.resolve("id135", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id135", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 136: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1271,7 +1211,7 @@ describe("State Transition Tests", () => {
     await promises.create("id136", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id136", undefined, false, undefined);
 
-    await expect(promises.resolve("id136", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id136", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 137: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1279,7 +1219,7 @@ describe("State Transition Tests", () => {
     await promises.create("id137", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id137", undefined, false, undefined);
 
-    await expect(promises.resolve("id137", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id137", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 138: transitions from Rejected to Rejected via Reject", async () => {
@@ -1287,7 +1227,7 @@ describe("State Transition Tests", () => {
     await promises.create("id138", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id138", undefined, false, undefined);
 
-    await expect(promises.reject("id138", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id138", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 139: transitions from Rejected to Rejected via Reject", async () => {
@@ -1295,7 +1235,7 @@ describe("State Transition Tests", () => {
     await promises.create("id139", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id139", undefined, false, undefined);
 
-    await expect(promises.reject("id139", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id139", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 140: transitions from Rejected to Rejected via Reject", async () => {
@@ -1303,7 +1243,7 @@ describe("State Transition Tests", () => {
     await promises.create("id140", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id140", undefined, false, undefined);
 
-    await expect(promises.reject("id140", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id140", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 141: transitions from Rejected to Rejected via Reject", async () => {
@@ -1311,7 +1251,7 @@ describe("State Transition Tests", () => {
     await promises.create("id141", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id141", undefined, false, undefined);
 
-    await expect(promises.reject("id141", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id141", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 142: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1319,7 +1259,7 @@ describe("State Transition Tests", () => {
     await promises.create("id142", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id142", undefined, false, undefined);
 
-    await expect(promises.cancel("id142", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id142", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 143: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1327,7 +1267,7 @@ describe("State Transition Tests", () => {
     await promises.create("id143", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id143", undefined, false, undefined);
 
-    await expect(promises.cancel("id143", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id143", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 144: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1335,7 +1275,7 @@ describe("State Transition Tests", () => {
     await promises.create("id144", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id144", undefined, false, undefined);
 
-    await expect(promises.cancel("id144", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id144", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 145: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1343,7 +1283,7 @@ describe("State Transition Tests", () => {
     await promises.create("id145", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id145", undefined, false, undefined);
 
-    await expect(promises.cancel("id145", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id145", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 146: transitions from Rejected to Rejected via Create", async () => {
@@ -1351,9 +1291,7 @@ describe("State Transition Tests", () => {
     await promises.create("id146", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id146", "iku", false, undefined);
 
-    await expect(
-      promises.create("id146", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id146", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 147: transitions from Rejected to Rejected via Create", async () => {
@@ -1361,9 +1299,7 @@ describe("State Transition Tests", () => {
     await promises.create("id147", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id147", "iku", false, undefined);
 
-    await expect(
-      promises.create("id147", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id147", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 148: transitions from Rejected to Rejected via Create", async () => {
@@ -1371,9 +1307,7 @@ describe("State Transition Tests", () => {
     await promises.create("id148", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id148", "iku", false, undefined);
 
-    await expect(promises.create("id148", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id148", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 149: transitions from Rejected to Rejected via Create", async () => {
@@ -1381,9 +1315,7 @@ describe("State Transition Tests", () => {
     await promises.create("id149", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id149", "iku", false, undefined);
 
-    await expect(promises.create("id149", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id149", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 150: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1391,7 +1323,7 @@ describe("State Transition Tests", () => {
     await promises.create("id150", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id150", "iku", false, undefined);
 
-    await expect(promises.resolve("id150", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id150", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 151: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1399,7 +1331,7 @@ describe("State Transition Tests", () => {
     await promises.create("id151", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id151", "iku", false, undefined);
 
-    await expect(promises.resolve("id151", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id151", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 152: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1407,7 +1339,7 @@ describe("State Transition Tests", () => {
     await promises.create("id152", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id152", "iku", false, undefined);
 
-    await expect(promises.resolve("id152", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id152", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 153: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1428,7 +1360,7 @@ describe("State Transition Tests", () => {
     await promises.create("id154", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id154", "iku", false, undefined);
 
-    await expect(promises.resolve("id154", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id154", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 155: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1436,7 +1368,7 @@ describe("State Transition Tests", () => {
     await promises.create("id155", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id155", "iku", false, undefined);
 
-    await expect(promises.resolve("id155", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id155", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 156: transitions from Rejected to Rejected via Reject", async () => {
@@ -1444,7 +1376,7 @@ describe("State Transition Tests", () => {
     await promises.create("id156", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id156", "iku", false, undefined);
 
-    await expect(promises.reject("id156", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id156", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 157: transitions from Rejected to Rejected via Reject", async () => {
@@ -1452,7 +1384,7 @@ describe("State Transition Tests", () => {
     await promises.create("id157", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id157", "iku", false, undefined);
 
-    await expect(promises.reject("id157", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id157", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 158: transitions from Rejected to Rejected via Reject", async () => {
@@ -1486,7 +1418,7 @@ describe("State Transition Tests", () => {
     await promises.create("id160", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id160", "iku", false, undefined);
 
-    await expect(promises.reject("id160", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id160", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 161: transitions from Rejected to Rejected via Reject", async () => {
@@ -1494,7 +1426,7 @@ describe("State Transition Tests", () => {
     await promises.create("id161", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id161", "iku", false, undefined);
 
-    await expect(promises.reject("id161", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id161", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 162: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1502,7 +1434,7 @@ describe("State Transition Tests", () => {
     await promises.create("id162", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id162", "iku", false, undefined);
 
-    await expect(promises.cancel("id162", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id162", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 163: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1510,7 +1442,7 @@ describe("State Transition Tests", () => {
     await promises.create("id163", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id163", "iku", false, undefined);
 
-    await expect(promises.cancel("id163", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id163", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 164: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1518,7 +1450,7 @@ describe("State Transition Tests", () => {
     await promises.create("id164", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id164", "iku", false, undefined);
 
-    await expect(promises.cancel("id164", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id164", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 165: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1539,7 +1471,7 @@ describe("State Transition Tests", () => {
     await promises.create("id166", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id166", "iku", false, undefined);
 
-    await expect(promises.cancel("id166", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id166", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 167: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1547,7 +1479,7 @@ describe("State Transition Tests", () => {
     await promises.create("id167", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.reject("id167", "iku", false, undefined);
 
-    await expect(promises.cancel("id167", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id167", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 168: transitions from Rejected to Rejected via Create", async () => {
@@ -1555,9 +1487,7 @@ describe("State Transition Tests", () => {
     await promises.create("id168", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id168", undefined, false, undefined);
 
-    await expect(
-      promises.create("id168", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id168", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 169: transitions from Rejected to Rejected via Create", async () => {
@@ -1565,9 +1495,7 @@ describe("State Transition Tests", () => {
     await promises.create("id169", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id169", undefined, false, undefined);
 
-    await expect(
-      promises.create("id169", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id169", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 170: transitions from Rejected to Rejected via Create", async () => {
@@ -1575,9 +1503,7 @@ describe("State Transition Tests", () => {
     await promises.create("id170", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id170", undefined, false, undefined);
 
-    await expect(promises.create("id170", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id170", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 171: transitions from Rejected to Rejected via Create", async () => {
@@ -1598,9 +1524,7 @@ describe("State Transition Tests", () => {
     await promises.create("id172", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id172", undefined, false, undefined);
 
-    await expect(promises.create("id172", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id172", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 173: transitions from Rejected to Rejected via Create", async () => {
@@ -1608,9 +1532,7 @@ describe("State Transition Tests", () => {
     await promises.create("id173", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id173", undefined, false, undefined);
 
-    await expect(promises.create("id173", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id173", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 174: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1618,7 +1540,7 @@ describe("State Transition Tests", () => {
     await promises.create("id174", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id174", undefined, false, undefined);
 
-    await expect(promises.resolve("id174", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id174", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 175: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1626,7 +1548,7 @@ describe("State Transition Tests", () => {
     await promises.create("id175", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id175", undefined, false, undefined);
 
-    await expect(promises.resolve("id175", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id175", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 176: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1634,7 +1556,7 @@ describe("State Transition Tests", () => {
     await promises.create("id176", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id176", undefined, false, undefined);
 
-    await expect(promises.resolve("id176", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id176", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 177: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1642,7 +1564,7 @@ describe("State Transition Tests", () => {
     await promises.create("id177", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id177", undefined, false, undefined);
 
-    await expect(promises.resolve("id177", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id177", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 178: transitions from Rejected to Rejected via Reject", async () => {
@@ -1650,7 +1572,7 @@ describe("State Transition Tests", () => {
     await promises.create("id178", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id178", undefined, false, undefined);
 
-    await expect(promises.reject("id178", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id178", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 179: transitions from Rejected to Rejected via Reject", async () => {
@@ -1658,7 +1580,7 @@ describe("State Transition Tests", () => {
     await promises.create("id179", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id179", undefined, false, undefined);
 
-    await expect(promises.reject("id179", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id179", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 180: transitions from Rejected to Rejected via Reject", async () => {
@@ -1666,7 +1588,7 @@ describe("State Transition Tests", () => {
     await promises.create("id180", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id180", undefined, false, undefined);
 
-    await expect(promises.reject("id180", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id180", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 181: transitions from Rejected to Rejected via Reject", async () => {
@@ -1674,7 +1596,7 @@ describe("State Transition Tests", () => {
     await promises.create("id181", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id181", undefined, false, undefined);
 
-    await expect(promises.reject("id181", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id181", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 182: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1682,7 +1604,7 @@ describe("State Transition Tests", () => {
     await promises.create("id182", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id182", undefined, false, undefined);
 
-    await expect(promises.cancel("id182", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id182", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 183: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1690,7 +1612,7 @@ describe("State Transition Tests", () => {
     await promises.create("id183", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id183", undefined, false, undefined);
 
-    await expect(promises.cancel("id183", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id183", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 184: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1698,7 +1620,7 @@ describe("State Transition Tests", () => {
     await promises.create("id184", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id184", undefined, false, undefined);
 
-    await expect(promises.cancel("id184", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id184", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 185: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1706,7 +1628,7 @@ describe("State Transition Tests", () => {
     await promises.create("id185", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id185", undefined, false, undefined);
 
-    await expect(promises.cancel("id185", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id185", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 186: transitions from Rejected to Rejected via Create", async () => {
@@ -1714,9 +1636,7 @@ describe("State Transition Tests", () => {
     await promises.create("id186", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id186", "iku", false, undefined);
 
-    await expect(
-      promises.create("id186", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id186", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 187: transitions from Rejected to Rejected via Create", async () => {
@@ -1724,9 +1644,7 @@ describe("State Transition Tests", () => {
     await promises.create("id187", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id187", "iku", false, undefined);
 
-    await expect(
-      promises.create("id187", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id187", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 188: transitions from Rejected to Rejected via Create", async () => {
@@ -1734,9 +1652,7 @@ describe("State Transition Tests", () => {
     await promises.create("id188", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id188", "iku", false, undefined);
 
-    await expect(promises.create("id188", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id188", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 189: transitions from Rejected to Rejected via Create", async () => {
@@ -1757,9 +1673,7 @@ describe("State Transition Tests", () => {
     await promises.create("id190", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id190", "iku", false, undefined);
 
-    await expect(promises.create("id190", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id190", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 191: transitions from Rejected to Rejected via Create", async () => {
@@ -1767,9 +1681,7 @@ describe("State Transition Tests", () => {
     await promises.create("id191", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id191", "iku", false, undefined);
 
-    await expect(promises.create("id191", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id191", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 192: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1777,7 +1689,7 @@ describe("State Transition Tests", () => {
     await promises.create("id192", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id192", "iku", false, undefined);
 
-    await expect(promises.resolve("id192", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id192", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 193: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1785,7 +1697,7 @@ describe("State Transition Tests", () => {
     await promises.create("id193", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id193", "iku", false, undefined);
 
-    await expect(promises.resolve("id193", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id193", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 194: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1793,7 +1705,7 @@ describe("State Transition Tests", () => {
     await promises.create("id194", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id194", "iku", false, undefined);
 
-    await expect(promises.resolve("id194", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id194", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 195: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1814,7 +1726,7 @@ describe("State Transition Tests", () => {
     await promises.create("id196", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id196", "iku", false, undefined);
 
-    await expect(promises.resolve("id196", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id196", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 197: transitions from Rejected to Rejected via Resolve", async () => {
@@ -1822,7 +1734,7 @@ describe("State Transition Tests", () => {
     await promises.create("id197", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id197", "iku", false, undefined);
 
-    await expect(promises.resolve("id197", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id197", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 198: transitions from Rejected to Rejected via Reject", async () => {
@@ -1830,7 +1742,7 @@ describe("State Transition Tests", () => {
     await promises.create("id198", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id198", "iku", false, undefined);
 
-    await expect(promises.reject("id198", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id198", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 199: transitions from Rejected to Rejected via Reject", async () => {
@@ -1838,7 +1750,7 @@ describe("State Transition Tests", () => {
     await promises.create("id199", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id199", "iku", false, undefined);
 
-    await expect(promises.reject("id199", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id199", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 200: transitions from Rejected to Rejected via Reject", async () => {
@@ -1872,7 +1784,7 @@ describe("State Transition Tests", () => {
     await promises.create("id202", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id202", "iku", false, undefined);
 
-    await expect(promises.reject("id202", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id202", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 203: transitions from Rejected to Rejected via Reject", async () => {
@@ -1880,7 +1792,7 @@ describe("State Transition Tests", () => {
     await promises.create("id203", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id203", "iku", false, undefined);
 
-    await expect(promises.reject("id203", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id203", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 204: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1888,7 +1800,7 @@ describe("State Transition Tests", () => {
     await promises.create("id204", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id204", "iku", false, undefined);
 
-    await expect(promises.cancel("id204", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id204", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 205: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1896,7 +1808,7 @@ describe("State Transition Tests", () => {
     await promises.create("id205", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id205", "iku", false, undefined);
 
-    await expect(promises.cancel("id205", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id205", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 206: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1904,7 +1816,7 @@ describe("State Transition Tests", () => {
     await promises.create("id206", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id206", "iku", false, undefined);
 
-    await expect(promises.cancel("id206", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id206", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 207: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1925,7 +1837,7 @@ describe("State Transition Tests", () => {
     await promises.create("id208", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id208", "iku", false, undefined);
 
-    await expect(promises.cancel("id208", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id208", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 209: transitions from Rejected to Rejected via Cancel", async () => {
@@ -1933,7 +1845,7 @@ describe("State Transition Tests", () => {
     await promises.create("id209", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.reject("id209", "iku", false, undefined);
 
-    await expect(promises.cancel("id209", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id209", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 210: transitions from Canceled to Canceled via Create", async () => {
@@ -1941,9 +1853,7 @@ describe("State Transition Tests", () => {
     await promises.create("id210", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id210", undefined, false, undefined);
 
-    await expect(
-      promises.create("id210", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id210", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 211: transitions from Canceled to Canceled via Create", async () => {
@@ -1951,9 +1861,7 @@ describe("State Transition Tests", () => {
     await promises.create("id211", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id211", undefined, false, undefined);
 
-    await expect(
-      promises.create("id211", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id211", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 212: transitions from Canceled to Canceled via Create", async () => {
@@ -1961,9 +1869,7 @@ describe("State Transition Tests", () => {
     await promises.create("id212", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id212", undefined, false, undefined);
 
-    await expect(promises.create("id212", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id212", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 213: transitions from Canceled to Canceled via Create", async () => {
@@ -1971,9 +1877,7 @@ describe("State Transition Tests", () => {
     await promises.create("id213", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id213", undefined, false, undefined);
 
-    await expect(promises.create("id213", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id213", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 214: transitions from Canceled to Canceled via Resolve", async () => {
@@ -1981,7 +1885,7 @@ describe("State Transition Tests", () => {
     await promises.create("id214", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id214", undefined, false, undefined);
 
-    await expect(promises.resolve("id214", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id214", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 215: transitions from Canceled to Canceled via Resolve", async () => {
@@ -1989,7 +1893,7 @@ describe("State Transition Tests", () => {
     await promises.create("id215", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id215", undefined, false, undefined);
 
-    await expect(promises.resolve("id215", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id215", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 216: transitions from Canceled to Canceled via Resolve", async () => {
@@ -1997,7 +1901,7 @@ describe("State Transition Tests", () => {
     await promises.create("id216", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id216", undefined, false, undefined);
 
-    await expect(promises.resolve("id216", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id216", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 217: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2005,7 +1909,7 @@ describe("State Transition Tests", () => {
     await promises.create("id217", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id217", undefined, false, undefined);
 
-    await expect(promises.resolve("id217", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id217", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 218: transitions from Canceled to Canceled via Reject", async () => {
@@ -2013,7 +1917,7 @@ describe("State Transition Tests", () => {
     await promises.create("id218", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id218", undefined, false, undefined);
 
-    await expect(promises.reject("id218", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id218", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 219: transitions from Canceled to Canceled via Reject", async () => {
@@ -2021,7 +1925,7 @@ describe("State Transition Tests", () => {
     await promises.create("id219", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id219", undefined, false, undefined);
 
-    await expect(promises.reject("id219", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id219", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 220: transitions from Canceled to Canceled via Reject", async () => {
@@ -2029,7 +1933,7 @@ describe("State Transition Tests", () => {
     await promises.create("id220", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id220", undefined, false, undefined);
 
-    await expect(promises.reject("id220", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id220", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 221: transitions from Canceled to Canceled via Reject", async () => {
@@ -2037,7 +1941,7 @@ describe("State Transition Tests", () => {
     await promises.create("id221", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id221", undefined, false, undefined);
 
-    await expect(promises.reject("id221", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id221", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 222: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2045,7 +1949,7 @@ describe("State Transition Tests", () => {
     await promises.create("id222", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id222", undefined, false, undefined);
 
-    await expect(promises.cancel("id222", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id222", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 223: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2053,7 +1957,7 @@ describe("State Transition Tests", () => {
     await promises.create("id223", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id223", undefined, false, undefined);
 
-    await expect(promises.cancel("id223", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id223", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 224: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2061,7 +1965,7 @@ describe("State Transition Tests", () => {
     await promises.create("id224", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id224", undefined, false, undefined);
 
-    await expect(promises.cancel("id224", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id224", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 225: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2069,7 +1973,7 @@ describe("State Transition Tests", () => {
     await promises.create("id225", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id225", undefined, false, undefined);
 
-    await expect(promises.cancel("id225", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id225", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 226: transitions from Canceled to Canceled via Create", async () => {
@@ -2077,9 +1981,7 @@ describe("State Transition Tests", () => {
     await promises.create("id226", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id226", "iku", false, undefined);
 
-    await expect(
-      promises.create("id226", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id226", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 227: transitions from Canceled to Canceled via Create", async () => {
@@ -2087,9 +1989,7 @@ describe("State Transition Tests", () => {
     await promises.create("id227", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id227", "iku", false, undefined);
 
-    await expect(
-      promises.create("id227", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id227", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 228: transitions from Canceled to Canceled via Create", async () => {
@@ -2097,9 +1997,7 @@ describe("State Transition Tests", () => {
     await promises.create("id228", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id228", "iku", false, undefined);
 
-    await expect(promises.create("id228", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id228", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 229: transitions from Canceled to Canceled via Create", async () => {
@@ -2107,9 +2005,7 @@ describe("State Transition Tests", () => {
     await promises.create("id229", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id229", "iku", false, undefined);
 
-    await expect(promises.create("id229", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id229", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 230: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2117,7 +2013,7 @@ describe("State Transition Tests", () => {
     await promises.create("id230", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id230", "iku", false, undefined);
 
-    await expect(promises.resolve("id230", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id230", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 231: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2125,7 +2021,7 @@ describe("State Transition Tests", () => {
     await promises.create("id231", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id231", "iku", false, undefined);
 
-    await expect(promises.resolve("id231", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id231", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 232: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2133,7 +2029,7 @@ describe("State Transition Tests", () => {
     await promises.create("id232", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id232", "iku", false, undefined);
 
-    await expect(promises.resolve("id232", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id232", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 233: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2154,7 +2050,7 @@ describe("State Transition Tests", () => {
     await promises.create("id234", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id234", "iku", false, undefined);
 
-    await expect(promises.resolve("id234", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id234", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 235: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2162,7 +2058,7 @@ describe("State Transition Tests", () => {
     await promises.create("id235", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id235", "iku", false, undefined);
 
-    await expect(promises.resolve("id235", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id235", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 236: transitions from Canceled to Canceled via Reject", async () => {
@@ -2170,7 +2066,7 @@ describe("State Transition Tests", () => {
     await promises.create("id236", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id236", "iku", false, undefined);
 
-    await expect(promises.reject("id236", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id236", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 237: transitions from Canceled to Canceled via Reject", async () => {
@@ -2178,7 +2074,7 @@ describe("State Transition Tests", () => {
     await promises.create("id237", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id237", "iku", false, undefined);
 
-    await expect(promises.reject("id237", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id237", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 238: transitions from Canceled to Canceled via Reject", async () => {
@@ -2186,7 +2082,7 @@ describe("State Transition Tests", () => {
     await promises.create("id238", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id238", "iku", false, undefined);
 
-    await expect(promises.reject("id238", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id238", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 239: transitions from Canceled to Canceled via Reject", async () => {
@@ -2207,7 +2103,7 @@ describe("State Transition Tests", () => {
     await promises.create("id240", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id240", "iku", false, undefined);
 
-    await expect(promises.reject("id240", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id240", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 241: transitions from Canceled to Canceled via Reject", async () => {
@@ -2215,7 +2111,7 @@ describe("State Transition Tests", () => {
     await promises.create("id241", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id241", "iku", false, undefined);
 
-    await expect(promises.reject("id241", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id241", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 242: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2223,7 +2119,7 @@ describe("State Transition Tests", () => {
     await promises.create("id242", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id242", "iku", false, undefined);
 
-    await expect(promises.cancel("id242", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id242", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 243: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2231,7 +2127,7 @@ describe("State Transition Tests", () => {
     await promises.create("id243", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id243", "iku", false, undefined);
 
-    await expect(promises.cancel("id243", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id243", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 244: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2265,7 +2161,7 @@ describe("State Transition Tests", () => {
     await promises.create("id246", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id246", "iku", false, undefined);
 
-    await expect(promises.cancel("id246", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id246", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 247: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2273,7 +2169,7 @@ describe("State Transition Tests", () => {
     await promises.create("id247", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {});
     await promises.cancel("id247", "iku", false, undefined);
 
-    await expect(promises.cancel("id247", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id247", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 248: transitions from Canceled to Canceled via Create", async () => {
@@ -2281,9 +2177,7 @@ describe("State Transition Tests", () => {
     await promises.create("id248", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id248", undefined, false, undefined);
 
-    await expect(
-      promises.create("id248", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id248", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 249: transitions from Canceled to Canceled via Create", async () => {
@@ -2291,9 +2185,7 @@ describe("State Transition Tests", () => {
     await promises.create("id249", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id249", undefined, false, undefined);
 
-    await expect(
-      promises.create("id249", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id249", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 250: transitions from Canceled to Canceled via Create", async () => {
@@ -2301,9 +2193,7 @@ describe("State Transition Tests", () => {
     await promises.create("id250", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id250", undefined, false, undefined);
 
-    await expect(promises.create("id250", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id250", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 251: transitions from Canceled to Canceled via Create", async () => {
@@ -2324,9 +2214,7 @@ describe("State Transition Tests", () => {
     await promises.create("id252", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id252", undefined, false, undefined);
 
-    await expect(promises.create("id252", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id252", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 253: transitions from Canceled to Canceled via Create", async () => {
@@ -2334,9 +2222,7 @@ describe("State Transition Tests", () => {
     await promises.create("id253", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id253", undefined, false, undefined);
 
-    await expect(promises.create("id253", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id253", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 254: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2344,7 +2230,7 @@ describe("State Transition Tests", () => {
     await promises.create("id254", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id254", undefined, false, undefined);
 
-    await expect(promises.resolve("id254", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id254", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 255: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2352,7 +2238,7 @@ describe("State Transition Tests", () => {
     await promises.create("id255", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id255", undefined, false, undefined);
 
-    await expect(promises.resolve("id255", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id255", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 256: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2360,7 +2246,7 @@ describe("State Transition Tests", () => {
     await promises.create("id256", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id256", undefined, false, undefined);
 
-    await expect(promises.resolve("id256", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id256", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 257: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2368,7 +2254,7 @@ describe("State Transition Tests", () => {
     await promises.create("id257", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id257", undefined, false, undefined);
 
-    await expect(promises.resolve("id257", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id257", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 258: transitions from Canceled to Canceled via Reject", async () => {
@@ -2376,7 +2262,7 @@ describe("State Transition Tests", () => {
     await promises.create("id258", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id258", undefined, false, undefined);
 
-    await expect(promises.reject("id258", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id258", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 259: transitions from Canceled to Canceled via Reject", async () => {
@@ -2384,7 +2270,7 @@ describe("State Transition Tests", () => {
     await promises.create("id259", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id259", undefined, false, undefined);
 
-    await expect(promises.reject("id259", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id259", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 260: transitions from Canceled to Canceled via Reject", async () => {
@@ -2392,7 +2278,7 @@ describe("State Transition Tests", () => {
     await promises.create("id260", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id260", undefined, false, undefined);
 
-    await expect(promises.reject("id260", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id260", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 261: transitions from Canceled to Canceled via Reject", async () => {
@@ -2400,7 +2286,7 @@ describe("State Transition Tests", () => {
     await promises.create("id261", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id261", undefined, false, undefined);
 
-    await expect(promises.reject("id261", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id261", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 262: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2408,7 +2294,7 @@ describe("State Transition Tests", () => {
     await promises.create("id262", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id262", undefined, false, undefined);
 
-    await expect(promises.cancel("id262", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id262", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 263: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2416,7 +2302,7 @@ describe("State Transition Tests", () => {
     await promises.create("id263", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id263", undefined, false, undefined);
 
-    await expect(promises.cancel("id263", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id263", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 264: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2424,7 +2310,7 @@ describe("State Transition Tests", () => {
     await promises.create("id264", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id264", undefined, false, undefined);
 
-    await expect(promises.cancel("id264", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id264", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 265: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2432,7 +2318,7 @@ describe("State Transition Tests", () => {
     await promises.create("id265", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id265", undefined, false, undefined);
 
-    await expect(promises.cancel("id265", "iku", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id265", "iku", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 266: transitions from Canceled to Canceled via Create", async () => {
@@ -2440,9 +2326,7 @@ describe("State Transition Tests", () => {
     await promises.create("id266", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id266", "iku", false, undefined);
 
-    await expect(
-      promises.create("id266", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id266", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 267: transitions from Canceled to Canceled via Create", async () => {
@@ -2450,9 +2334,7 @@ describe("State Transition Tests", () => {
     await promises.create("id267", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id267", "iku", false, undefined);
 
-    await expect(
-      promises.create("id267", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id267", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 268: transitions from Canceled to Canceled via Create", async () => {
@@ -2460,9 +2342,7 @@ describe("State Transition Tests", () => {
     await promises.create("id268", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id268", "iku", false, undefined);
 
-    await expect(promises.create("id268", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id268", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 269: transitions from Canceled to Canceled via Create", async () => {
@@ -2483,9 +2363,7 @@ describe("State Transition Tests", () => {
     await promises.create("id270", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id270", "iku", false, undefined);
 
-    await expect(promises.create("id270", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id270", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 271: transitions from Canceled to Canceled via Create", async () => {
@@ -2493,9 +2371,7 @@ describe("State Transition Tests", () => {
     await promises.create("id271", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id271", "iku", false, undefined);
 
-    await expect(promises.create("id271", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id271", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 272: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2503,7 +2379,7 @@ describe("State Transition Tests", () => {
     await promises.create("id272", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id272", "iku", false, undefined);
 
-    await expect(promises.resolve("id272", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id272", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 273: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2511,7 +2387,7 @@ describe("State Transition Tests", () => {
     await promises.create("id273", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id273", "iku", false, undefined);
 
-    await expect(promises.resolve("id273", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id273", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 274: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2519,7 +2395,7 @@ describe("State Transition Tests", () => {
     await promises.create("id274", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id274", "iku", false, undefined);
 
-    await expect(promises.resolve("id274", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id274", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 275: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2540,7 +2416,7 @@ describe("State Transition Tests", () => {
     await promises.create("id276", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id276", "iku", false, undefined);
 
-    await expect(promises.resolve("id276", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id276", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 277: transitions from Canceled to Canceled via Resolve", async () => {
@@ -2548,7 +2424,7 @@ describe("State Transition Tests", () => {
     await promises.create("id277", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id277", "iku", false, undefined);
 
-    await expect(promises.resolve("id277", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id277", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 278: transitions from Canceled to Canceled via Reject", async () => {
@@ -2556,7 +2432,7 @@ describe("State Transition Tests", () => {
     await promises.create("id278", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id278", "iku", false, undefined);
 
-    await expect(promises.reject("id278", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id278", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 279: transitions from Canceled to Canceled via Reject", async () => {
@@ -2564,7 +2440,7 @@ describe("State Transition Tests", () => {
     await promises.create("id279", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id279", "iku", false, undefined);
 
-    await expect(promises.reject("id279", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id279", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 280: transitions from Canceled to Canceled via Reject", async () => {
@@ -2572,7 +2448,7 @@ describe("State Transition Tests", () => {
     await promises.create("id280", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id280", "iku", false, undefined);
 
-    await expect(promises.reject("id280", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id280", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 281: transitions from Canceled to Canceled via Reject", async () => {
@@ -2593,7 +2469,7 @@ describe("State Transition Tests", () => {
     await promises.create("id282", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id282", "iku", false, undefined);
 
-    await expect(promises.reject("id282", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id282", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 283: transitions from Canceled to Canceled via Reject", async () => {
@@ -2601,7 +2477,7 @@ describe("State Transition Tests", () => {
     await promises.create("id283", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id283", "iku", false, undefined);
 
-    await expect(promises.reject("id283", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id283", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 284: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2609,7 +2485,7 @@ describe("State Transition Tests", () => {
     await promises.create("id284", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id284", "iku", false, undefined);
 
-    await expect(promises.cancel("id284", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id284", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 285: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2617,7 +2493,7 @@ describe("State Transition Tests", () => {
     await promises.create("id285", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id285", "iku", false, undefined);
 
-    await expect(promises.cancel("id285", undefined, false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id285", undefined, false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 286: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2651,7 +2527,7 @@ describe("State Transition Tests", () => {
     await promises.create("id288", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id288", "iku", false, undefined);
 
-    await expect(promises.cancel("id288", "iku*", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id288", "iku*", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 289: transitions from Canceled to Canceled via Cancel", async () => {
@@ -2659,50 +2535,42 @@ describe("State Transition Tests", () => {
     await promises.create("id289", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {});
     await promises.cancel("id289", "iku", false, undefined);
 
-    await expect(promises.cancel("id289", "iku*", false, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id289", "iku*", false, undefined)).rejects.toThrow();
   });
 
   test("Test Case 290: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id290", 0, undefined, false, undefined, {});
 
-    await expect(
-      promises.create("id290", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id290", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 291: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id291", 0, undefined, false, undefined, {});
 
-    await expect(
-      promises.create("id291", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id291", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 292: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id292", 0, undefined, false, undefined, {});
 
-    await expect(promises.create("id292", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id292", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 293: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id293", 0, undefined, false, undefined, {});
 
-    await expect(promises.create("id293", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id293", Number.MAX_SAFE_INTEGER, "ikc", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 294: transitions from Timedout to Timedout via Resolve", async () => {
     const promises = new Promises();
     await promises.create("id294", 0, undefined, false, undefined, {});
 
-    await expect(promises.resolve("id294", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id294", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 295: transitions from Timedout to Timedout via Resolve", async () => {
@@ -2721,7 +2589,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id296", 0, undefined, false, undefined, {});
 
-    await expect(promises.resolve("id296", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id296", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 297: transitions from Timedout to Timedout via Resolve", async () => {
@@ -2740,7 +2608,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id298", 0, undefined, false, undefined, {});
 
-    await expect(promises.reject("id298", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id298", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 299: transitions from Timedout to Timedout via Reject", async () => {
@@ -2759,7 +2627,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id300", 0, undefined, false, undefined, {});
 
-    await expect(promises.reject("id300", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id300", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 301: transitions from Timedout to Timedout via Reject", async () => {
@@ -2778,7 +2646,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id302", 0, undefined, false, undefined, {});
 
-    await expect(promises.cancel("id302", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id302", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 303: transitions from Timedout to Timedout via Cancel", async () => {
@@ -2797,7 +2665,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id304", 0, undefined, false, undefined, {});
 
-    await expect(promises.cancel("id304", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id304", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 305: transitions from Timedout to Timedout via Cancel", async () => {
@@ -2816,27 +2684,21 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id306", 0, "ikc", false, undefined, {});
 
-    await expect(
-      promises.create("id306", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id306", Number.MAX_SAFE_INTEGER, undefined, true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 307: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id307", 0, "ikc", false, undefined, {});
 
-    await expect(
-      promises.create("id307", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {}),
-    ).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.create("id307", Number.MAX_SAFE_INTEGER, undefined, false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 308: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id308", 0, "ikc", false, undefined, {});
 
-    await expect(promises.create("id308", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id308", Number.MAX_SAFE_INTEGER, "ikc", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 309: transitions from Timedout to Timedout via Create", async () => {
@@ -2855,25 +2717,21 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id310", 0, "ikc", false, undefined, {});
 
-    await expect(promises.create("id310", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(promises.create("id310", Number.MAX_SAFE_INTEGER, "ikc*", true, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 311: transitions from Timedout to Timedout via Create", async () => {
     const promises = new Promises();
     await promises.create("id311", 0, "ikc", false, undefined, {});
 
-    await expect(promises.create("id311", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toMatchObject(
-      { kind: "error" },
-    );
+    await expect(promises.create("id311", Number.MAX_SAFE_INTEGER, "ikc*", false, undefined, {})).rejects.toThrow();
   });
 
   test("Test Case 312: transitions from Timedout to Timedout via Resolve", async () => {
     const promises = new Promises();
     await promises.create("id312", 0, "ikc", false, undefined, {});
 
-    await expect(promises.resolve("id312", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id312", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 313: transitions from Timedout to Timedout via Resolve", async () => {
@@ -2892,7 +2750,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id314", 0, "ikc", false, undefined, {});
 
-    await expect(promises.resolve("id314", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.resolve("id314", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 315: transitions from Timedout to Timedout via Resolve", async () => {
@@ -2911,7 +2769,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id316", 0, "ikc", false, undefined, {});
 
-    await expect(promises.reject("id316", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id316", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 317: transitions from Timedout to Timedout via Reject", async () => {
@@ -2930,7 +2788,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id318", 0, "ikc", false, undefined, {});
 
-    await expect(promises.reject("id318", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.reject("id318", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 319: transitions from Timedout to Timedout via Reject", async () => {
@@ -2949,7 +2807,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id320", 0, "ikc", false, undefined, {});
 
-    await expect(promises.cancel("id320", undefined, true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id320", undefined, true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 321: transitions from Timedout to Timedout via Cancel", async () => {
@@ -2968,7 +2826,7 @@ describe("State Transition Tests", () => {
     const promises = new Promises();
     await promises.create("id322", 0, "ikc", false, undefined, {});
 
-    await expect(promises.cancel("id322", "iku", true, undefined)).rejects.toMatchObject({ kind: "error" });
+    await expect(promises.cancel("id322", "iku", true, undefined)).rejects.toThrow();
   });
 
   test("Test Case 323: transitions from Timedout to Timedout via Cancel", async () => {

--- a/tests/store.schedules.test.ts
+++ b/tests/store.schedules.test.ts
@@ -29,7 +29,7 @@ describe("schedule transitions", () => {
 
   test("test case 2: create twice without ikey", async () => {
     await schedules.create(id, "* * * * *", "foo", 10);
-    await expect(schedules.create(id, "* * * * *", "foo", 10)).rejects.toMatchObject({ kind: "error" });
+    await expect(schedules.create(id, "* * * * *", "foo", 10)).rejects.toThrow();
   });
 
   test("test case 3: create twich with ikey", async () => {

--- a/tests/store.tasks.test.ts
+++ b/tests/store.tasks.test.ts
@@ -50,14 +50,12 @@ describe("tasks transitions", () => {
 
   test("Test Case 6: transition from enqueue to enqueue via claim", async () => {
     const task = step(server);
-    await expect(tasks.claim(task.id, task.counter + 1, "task5", Number.MAX_SAFE_INTEGER)).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(tasks.claim(task.id, task.counter + 1, "task5", Number.MAX_SAFE_INTEGER)).rejects.toThrow();
   });
 
   test("Test Case 8: transition from enqueue to enqueue via complete", async () => {
     const task = step(server);
-    await expect(tasks.complete(task.id, task.counter)).rejects.toMatchObject({ kind: "error" });
+    await expect(tasks.complete(task.id, task.counter)).rejects.toThrow();
   });
 
   test("Test Case 10: transition from enqueue to enqueue via heartbeat", async () => {
@@ -68,17 +66,13 @@ describe("tasks transitions", () => {
   test("Test Case 12: transition from claimed to claimed via claim", async () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task12", Number.MAX_SAFE_INTEGER);
-    await expect(tasks.claim(task.id, task.counter, "task12", Number.MAX_SAFE_INTEGER)).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(tasks.claim(task.id, task.counter, "task12", Number.MAX_SAFE_INTEGER)).rejects.toThrow();
   });
 
   test("Test Case 13: transition from claimed to init via claim", async () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task13", 0);
-    await expect(tasks.claim(task.id, task.counter, "task12", Number.MAX_SAFE_INTEGER)).rejects.toMatchObject({
-      kind: "error",
-    });
+    await expect(tasks.claim(task.id, task.counter, "task12", Number.MAX_SAFE_INTEGER)).rejects.toThrow();
   });
 
   test("Test Case 14: transition from claimed to completed via complete", async () => {
@@ -91,20 +85,20 @@ describe("tasks transitions", () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task15", 0);
     await new Promise((r) => setTimeout(r, TICK_TIME));
-    await expect(tasks.complete(task.id, task.counter)).rejects.toMatchObject({ kind: "error" });
+    await expect(tasks.complete(task.id, task.counter)).rejects.toThrow();
   });
 
   test("Test Case 16: transition from claimed to claimed via complete", async () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task16", Number.MAX_SAFE_INTEGER);
-    await expect(tasks.complete(task.id, task.counter + 1)).rejects.toMatchObject({ kind: "error" });
+    await expect(tasks.complete(task.id, task.counter + 1)).rejects.toThrow();
   });
 
   test("Test Case 17: transition from claimed to init via complete (expired)", async () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task17", 0);
     await new Promise((r) => setTimeout(r, TICK_TIME));
-    await expect(tasks.complete(task.id, task.counter)).rejects.toMatchObject({ kind: "error" });
+    await expect(tasks.complete(task.id, task.counter)).rejects.toThrow();
   });
 
   test("Test Case 18: transition from claimed to claimed via heartbeat", async () => {
@@ -125,7 +119,7 @@ describe("tasks transitions", () => {
     const task = step(server);
     await tasks.claim(task.id, task.counter, "task20", Number.MAX_SAFE_INTEGER);
     await tasks.complete(task.id, task.counter);
-    await expect(tasks.claim(task.id, task.counter, "task20", 0)).rejects.toMatchObject({ kind: "error" });
+    await expect(tasks.claim(task.id, task.counter, "task20", 0)).rejects.toThrow();
   });
 
   test("Test Case 21: transition from completed to completed via complete", async () => {


### PR DESCRIPTION
```ts
export type ResponseFor<T extends Request> = Extract<Response, { kind: T["kind"] }>;
```

This utility type annotation lets us move the type casting behind the interface so that we only have to do it once in the callee rather than on the caller side. 

Example usage (in remote network implementation):
```ts
  send<T extends Request>(req: T, callback: (timeout: boolean, response?: ResponseFor<T>) => void): void {
    this.handleRequest(req).then(
      (res) => {
        util.assert(res.kind === req.kind, "res kind must match req kind");
        callback(false, res as ResponseFor<T>);
      },
      () => {
        // TODO: log error here
        callback(true);
      },
    );
  }
```