### PR TITLE
Set callback timeout to timeout of root promise

### DIFF
--- a/src/computation.ts
+++ b/src/computation.ts
@@ -183,7 +183,7 @@ export class Computation {
           if (status.todo.local.length > 0) {
             this.processLocalTodo(nursery, status.todo.local, done);
           } else if (status.todo.remote.length > 0) {
-            this.processRemoteTodo(nursery, status.todo.remote, done);
+            this.processRemoteTodo(nursery, status.todo.remote, ctx.timeout, done);
           }
           break;
       }
@@ -235,14 +235,19 @@ export class Computation {
     return nursery.cont();
   }
 
-  private processRemoteTodo(nursery: Nursery<boolean, Status>, todo: RemoteTodo[], done: Callback<Status>) {
+  private processRemoteTodo(
+    nursery: Nursery<boolean, Status>,
+    todo: RemoteTodo[],
+    timeout: number,
+    done: Callback<Status>,
+  ) {
     nursery.all<
       RemoteTodo,
       { kind: "callback"; callback: CallbackRecord } | { kind: "promise"; promise: DurablePromiseRecord },
       boolean
     >(
       todo,
-      ({ id, timeout }, done) =>
+      ({ id }, done) =>
         this.handler.createCallback(
           {
             kind: "createCallback",

--- a/src/coroutine.ts
+++ b/src/coroutine.ts
@@ -24,7 +24,6 @@ export interface LocalTodo {
 
 export interface RemoteTodo {
   id: string;
-  timeout: number;
 }
 
 type More = {
@@ -111,7 +110,6 @@ export class Coroutine<T> {
   private exec(callback: Callback<More | Done>) {
     const local: LocalTodo[] = [];
     const remote: RemoteTodo[] = [];
-    const detached: Map<string, RemoteTodo> = new Map();
 
     let input: Value<any> = {
       type: "internal.nothing",
@@ -209,8 +207,7 @@ export class Coroutine<T> {
             util.assertDefined(res);
 
             if (res.state === "pending") {
-              if (action.mode === "attached") remote.push({ id: action.id, timeout: res.timeout });
-              if (action.mode === "detached") detached.set(action.id, { id: action.id, timeout: res.timeout });
+              if (action.mode === "attached") remote.push({ id: action.id });
 
               input = {
                 type: "internal.promise",
@@ -246,12 +243,9 @@ export class Coroutine<T> {
         // the global callbacks to create.
         if (action.type === "internal.await" && action.promise.state === "pending") {
           if (action.promise.mode === "detached") {
-            const todo = detached.get(action.id);
-            util.assertDefined(todo);
-
             // We didn't add the associated todo of this promise, since the user is explicitly awaiting it we need to add the todo now.
             // All detached are remotes.
-            remote.push(todo);
+            remote.push({ id: action.id });
           }
           callback(false, { type: "more", todo: { local, remote } });
           return;

--- a/src/resonate-inner.ts
+++ b/src/resonate-inner.ts
@@ -158,7 +158,7 @@ export class ResonateInner {
             {
               kind: "createSubscription",
               id: id,
-              timeout: timeout,
+              timeout: timeout + 1 * util.MIN, // add a buffer
               recv: this.unicast,
             },
             (err, res) => {


### PR DESCRIPTION
Sets timeout of callbacks to root promise (not the callback the timeout is being registered against) and adds a buffer for the timeout on a subscription.