### PR TITLE
Create issues when dst fails

### DIFF
--- a/.github/workflows/dst.yml
+++ b/.github/workflows/dst.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run DST (seed=${{ needs.values.outputs.seed }}, steps=${{ needs.values.outputs.steps }})
         run: |
-          npm run dst -- --seed ${{ needs.values.outputs.seed }} --steps ${{ needs.values.outputs.steps }} 2> logs.txt
+          npm run dst -- --seed ${{ needs.values.outputs.seed }} --steps ${{ needs.values.outputs.steps }} > logs.txt
 
       - name: Create issue if dst failed
         if: ${{ failure() && matrix.run == 1 }}


### PR DESCRIPTION
You can see this issue in [this fork](https://github.com/dfarr/resonate-sdk-ts/issues).