### PR TITLE
Avoid arrow function to preserve now and random name

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -505,11 +505,11 @@ export class InnerContext implements Context {
   }
 
   readonly date = {
-    now: () => this.lfc(() => (this.getDependency<DateConstructor>("resonate:date") ?? Date).now()),
+    now: () => this.lfc((this.getDependency<DateConstructor>("resonate:date") ?? Date).now),
   };
 
   readonly math = {
-    random: () => this.lfc(() => (this.getDependency<Math>("resonate:math") ?? Math).random()),
+    random: () => this.lfc((this.getDependency<Math>("resonate:math") ?? Math).random),
   };
 
   localCreateReq(data: any, opts: Options): CreatePromiseReq {


### PR DESCRIPTION
This is functionality equivalent and preserves the function names "now" and "random" which come in handy.