### PR TITLE
Webapp exposed for local development

### DIFF
--- a/dev/network.ts
+++ b/dev/network.ts
@@ -1,3 +1,7 @@
+import type { Server as HttpServer } from "node:http";
+import KoaRouter from "@koa/router";
+import Koa, { type Context } from "koa";
+import bodyParser from "koa-bodyparser";
 import type { ResonateError } from "../src/exceptions";
 import type { Message, MessageSource, Network, Request, ResponseFor } from "../src/network/network";
 import * as util from "../src/util";
@@ -68,21 +72,297 @@ export interface LocalNetworkConfig {
   group?: string;
   server?: Server;
 }
+
+const koa = new Koa();
+
 export class LocalNetwork implements Network {
   private server: Server;
   private messageSource: LocalMessageSource;
+  private webapp: HttpServer | undefined = undefined;
 
   constructor({ pid = "pid", group = "default", server = new Server() }: LocalNetworkConfig = {}) {
     this.server = server;
     this.messageSource = new LocalMessageSource(pid, group, server);
+
+    const router = this.initializeRoutes(new KoaRouter());
+    koa.use(bodyParser());
+    koa.use(router.routes());
+    koa.use(router.allowedMethods());
+  }
+
+  private sendPromised(message: Request): Promise<ResponseFor<Request>> {
+    return new Promise((resolve, reject) => {
+      // The original this.send call
+      this.send(message, (err, res) => {
+        if (err !== undefined) {
+          // If there's an error, reject the Promise
+          reject(err);
+        } else {
+          util.assertDefined(res);
+          resolve(res);
+        }
+      });
+    });
+  }
+
+  private initializeRoutes(router: KoaRouter): KoaRouter {
+    router.get("/promises", async (ctx: Context) => {
+      const res = await this.sendPromised({ kind: "searchPromises", id: ctx.query.id as string });
+      if (res.kind !== "searchPromises") {
+        util.assert(false, "unreacheable");
+        return;
+      }
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = { promises: res.promises };
+    });
+
+    router.post("/promises", async (ctx: Context) => {
+      const { id, param, tags, timeout } = ctx.request.body as {
+        id: string;
+        param: any;
+        tags: Record<string, string>;
+        timeout: number;
+      };
+      const res = await this.sendPromised({
+        kind: "createPromise",
+        id,
+        param,
+        tags,
+        timeout,
+        strict: (ctx.request.headers.strict as string) === "true",
+        iKey: ctx.request.headers["idempotency-key"] as string,
+      });
+      if (res.kind !== "createPromise") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 201;
+      ctx.type = "application/json";
+      ctx.body = res.promise;
+    });
+
+    router.post("/promises/task", async (ctx: Context) => {
+      const { promise, task } = ctx.request.body as {
+        promise: { id: string; timeout: number; param: any; tags: Record<string, string> };
+        task: { processId: string; ttl: number };
+      };
+      const res = await this.sendPromised({
+        kind: "createPromiseAndTask",
+        promise,
+        task,
+        iKey: ctx.request.headers["idempotency-key"] as string,
+        strict: (ctx.request.headers.strict as string) === "true",
+      });
+
+      if (res.kind !== "createPromiseAndTask") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.type = "application/json";
+      ctx.status = res.task === undefined ? 200 : 201;
+      ctx.body = { promise: res.promise, task: res.task };
+    });
+
+    router.get("/promises/:id", async (ctx: Context) => {
+      const res = await this.sendPromised({ kind: "readPromise", id: ctx.params.id as string });
+      if (res.kind !== "readPromise") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = res.promise;
+    });
+
+    router.patch("/promises/:id", async (ctx: Context) => {
+      const { state, value } = ctx.request.body as {
+        state: string;
+        value: any;
+      };
+      const res = await this.sendPromised({
+        kind: "completePromise",
+        id: ctx.params.id as string,
+        state: state.toLowerCase() as "resolved" | "rejected" | "rejected_canceled",
+        value,
+        iKey: ctx.request.headers["idempotency-key"] as string,
+        strict: (ctx.request.headers.strict as string) === "true",
+      });
+
+      if (res.kind !== "completePromise") {
+        util.panic("unreachable");
+        return;
+      }
+
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = res.promise;
+    });
+
+    router.post("/promises/callback/:id", async (ctx: Context) => {
+      const promiseId = ctx.params.id as string;
+      const { rootPromiseId, timeout, recv } = ctx.request.body as {
+        rootPromiseId: string;
+        timeout: number;
+        recv: string;
+      };
+
+      const res = await this.sendPromised({ kind: "createCallback", promiseId, rootPromiseId, timeout, recv });
+      if (res.kind !== "createCallback") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = { promise: res.promise, callback: res.callback };
+    });
+
+    router.post("/promises/subscribe/:id", async (ctx: Context) => {
+      const promiseId = ctx.params.id as string;
+      const { id, timeout, recv } = ctx.request.body as {
+        id: string;
+        timeout: number;
+        recv: string;
+      };
+      const res = await this.sendPromised({ kind: "createSubscription", id, promiseId, timeout, recv });
+      if (res.kind !== "createSubscription") {
+        util.panic("unreachable");
+        return;
+      }
+
+      ctx.status = res.callback === undefined ? 200 : 201;
+      ctx.type = "application/json";
+      ctx.body = res;
+    });
+
+    router.get("/schedules", async (ctx: Context) => {
+      const res = await this.sendPromised({ kind: "searchSchedules", id: ctx.query.id as string });
+      if (res.kind !== "searchSchedules") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = { schedules: res.schedules };
+    });
+
+    router.post("/schedules", async (ctx: Context) => {
+      const { id, description, cron, tags, promiseId, promiseTimeout, promiseParam, promiseTags } = ctx.request
+        .body as {
+        id: string;
+        description: string;
+        cron: string;
+        tags: Record<string, string>;
+        promiseId: string;
+        promiseTimeout: number;
+        promiseParam: any; // Assuming 'Value' schema translates to 'any' here
+        promiseTags: Record<string, string>;
+        idempotencyKey: string;
+      };
+
+      const res = await this.sendPromised({
+        kind: "createSchedule",
+        id,
+        cron,
+        promiseId,
+        promiseTimeout,
+        iKey: ctx.request.headers["idempotency-key"] as string,
+        description,
+        tags,
+        promiseParam,
+        promiseTags,
+      });
+      if (res.kind !== "createSchedule") {
+        util.panic("unreachable");
+        return;
+      }
+
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = res;
+    });
+
+    router.get("/schedules/:id", async (ctx: Context) => {
+      const res = await this.sendPromised({ kind: "readSchedule", id: ctx.params.id as string });
+      if (res.kind !== "readSchedule") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 200;
+      ctx.type = "application/json";
+      ctx.body = res;
+    });
+
+    router.delete("/schedules/:id", async (ctx: Context) => {
+      const res = await this.sendPromised({ kind: "deleteSchedule", id: ctx.params.id as string });
+      if (res.kind !== "deleteSchedule") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.status = 204;
+      ctx.type = "application/json";
+    });
+
+    router.post("/tasks/claim", async (ctx: Context) => {
+      const { id, counter, processId, ttl } = ctx.request.body as {
+        id: string;
+        counter: number;
+        processId: string;
+        ttl: number;
+      };
+      const res = await this.sendPromised({ kind: "claimTask", id, counter, processId, ttl });
+      if (res.kind !== "claimTask") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.body = { type: res.message.kind, promises: res.message.promises };
+      ctx.status = 201;
+      ctx.type = "application/json";
+    });
+    router.post("/tasks/complete", async (ctx: Context) => {
+      const { id, counter } = ctx.request.body as {
+        id: string;
+        counter: number;
+      };
+      const res = await this.sendPromised({ kind: "completeTask", id, counter });
+      if (res.kind !== "completeTask") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.body = res.task;
+      ctx.status = 201;
+      ctx.type = "application/json";
+    });
+    router.post("/tasks/heartbeat", async (ctx: Context) => {
+      const { processId } = ctx.request.body as {
+        processId: string;
+      };
+      const res = await this.sendPromised({ kind: "heartbeatTasks", processId });
+      if (res.kind !== "heartbeatTasks") {
+        util.panic("unreachable");
+        return;
+      }
+      ctx.body = res.tasksAffected;
+      ctx.status = 200;
+      ctx.type = "application/json";
+    });
+
+    return router;
   }
 
   getMessageSource(): MessageSource {
     return this.messageSource;
   }
 
+  start() {
+    const port = 8001;
+    this.webapp = koa.listen(port, () => {
+      console.log(`time=${new Date().toISOString()} level=INFO msg="starting http server" addr=:${port}`);
+    });
+  }
+
   stop() {
-    // No-op for LocalNetwork, MessageSource handles polling cleanup
+    if (this.webapp !== undefined) this.webapp.close();
   }
 
   send<T extends Request>(req: Request, callback: (err?: ResonateError, res?: ResponseFor<T>) => void): void {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,19 @@
     "type-check": "npx tsc --noEmit"
   },
   "dependencies": {
+    "@koa/router": "^15.0.0",
     "cron-parser": "^5.3.0",
-    "eventsource": "^4.0.0"
+    "eventsource": "^4.0.0",
+    "koa": "^3.1.1",
+    "koa-bodyparser": "^4.4.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.6",
     "@jest/globals": "^30.0.0",
     "@types/jest": "30.0.0",
+    "@types/koa": "^3.0.1",
+    "@types/koa-bodyparser": "^4.3.13",
+    "@types/koa__router": "^12.0.5",
     "@types/node": "^24.0.0",
     "commander": "^14.0.0",
     "esbuild": "^0.27.0",

--- a/src/network/remote.ts
+++ b/src/network/remote.ts
@@ -187,7 +187,7 @@ export class HttpNetwork implements Network {
     );
   }
 
-  public stop(): void {
+  stop(): void {
     // No-op for HttpNetwork, MessageSource handles connection cleanup
   }
 

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -91,6 +91,7 @@ export class Resonate {
     encryptor = undefined,
     tracer = undefined,
     transport = undefined,
+    webapp = false,
   }: {
     url?: string;
     group?: string;
@@ -101,6 +102,7 @@ export class Resonate {
     encryptor?: Encryptor;
     tracer?: Tracer;
     transport?: Network & MessageSource;
+    webapp?: boolean;
   } = {}) {
     this.clock = new WallClock();
     this.ttl = ttl;
@@ -146,6 +148,7 @@ export class Resonate {
     } else {
       if (!resolvedUrl) {
         const localNetwork = new LocalNetwork({ pid, group });
+        if (webapp) localNetwork.start();
         this.network = localNetwork;
         this.messageSource = localNetwork.getMessageSource();
         this.pid = pid ?? this.messageSource.pid;
@@ -246,10 +249,12 @@ export class Resonate {
     verbose = false,
     encryptor = undefined,
     tracer = undefined,
+    webapp = false,
   }: {
     verbose?: boolean;
     encryptor?: Encryptor;
     tracer?: Tracer;
+    webapp?: boolean;
   } = {}): Resonate {
     return new Resonate({
       group: "default",
@@ -258,6 +263,7 @@ export class Resonate {
       verbose,
       encryptor,
       tracer,
+      webapp,
     });
   }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,6 +10,15 @@ export const HOUR = 60 * MIN;
 
 // assert
 
+export function panic(msg?: string): void {
+  console.assert(true, "Panic triggered: %s", msg);
+  console.trace();
+
+  if (typeof process !== "undefined" && process.versions.node) {
+    process.exit(1);
+  }
+}
+
 export function assert(cond: boolean, msg?: string): void {
   if (cond) return; // Early return if assertion passes
 


### PR DESCRIPTION
This is an initial version. But already working.

```typescript
// app.ts

import type { Context } from "./src/context";
import { Resonate } from "./src/resonate";

const resonate = Resonate.local({ webapp: true });

function* foo(ctx: Context): Generator {
  const v = yield* ctx.run(bar);
  return v;
}

function bar(ctx: Context): string {
  console.log("hello world!");
  return "hello world";
}

function* fib(ctx: Context, n: number): Generator {
  if (n <= 1) return n;
  const p1 = yield ctx.beginRpc(fib, n - 1);
  const p2 = yield ctx.beginRpc(fib, n - 2);
  return (yield p1) + (yield p2);
}
async function main() {
  resonate.register(foo, { version: 1 });
  resonate.register(fib, { version: 1 });
}
main();


```

```
bun run app.ts
// time=2025-12-04T02:50:25.110Z level=INFO msg="starting http server" addr=:8001

```

```
resonate invoke fib.2 --func fib --arg 5
```

```
resonate get fib.2
```