### PR TITLE
docs: document Resonate constructor defaults

### DIFF
--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -82,6 +82,28 @@ export class Resonate {
   public readonly promises: Promises;
   public readonly schedules: Schedules;
 
+  /**
+   * Creates a new Resonate client instance.
+   *
+   * @param options - Configuration options for the client.
+   * @param options.url - Resonate server URL. Defaults to `process.env.RESONATE_URL`,
+   *   otherwise builds from `process.env.RESONATE_SCHEME` (defaults to `"http"`),
+   *   `process.env.RESONATE_HOST`, and `process.env.RESONATE_PORT` (defaults to `"8001"`).
+   *   If no URL is resolved, a local in-memory network is used.
+   * @param options.group - Worker group name. Defaults to `"default"`.
+   * @param options.pid - Process identifier for the client. Defaults to the
+   *   message source's generated PID.
+   * @param options.ttl - Time-to-live (in seconds) for claimed tasks. Defaults to `1 * util.MIN`.
+   * @param options.auth - Basic authentication credentials. Defaults to
+   *   `process.env.RESONATE_USERNAME` and `process.env.RESONATE_PASSWORD` when set.
+   * @param options.token - Bearer token for authentication. Defaults to `process.env.RESONATE_TOKEN`.
+   * @param options.verbose - Enables verbose logging. Defaults to `false`.
+   * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
+   * @param options.tracer - Tracing implementation. Defaults to {@link NoopTracer}.
+   * @param options.transport - Custom network transport implementation. Defaults to `undefined`.
+   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
+   *   `process.env.RESONATE_PREFIX` when set.
+   */
   constructor({
     url = undefined,
     group = "default",


### PR DESCRIPTION
### Motivation
- Make the default behaviors and environment-variable fallbacks of the `Resonate` constructor explicit for the generated API reference.
- Ensure users can see how `url`, auth, token, `pid`, `group`, `ttl`, `prefix`, and other options are resolved without reading source.
- Improve discoverability of defaults for local vs remote modes and the default noop implementations for encryptor/tracer.

### Description
- Added a Typedoc/JSDoc block above the `Resonate` `constructor` documenting the `options` parameter and default resolution logic.
- Documented default resolution for `url` (including `process.env.RESONATE_URL`, `RESONATE_SCHEME`, `RESONATE_HOST`, `RESONATE_PORT`), `token` (`process.env.RESONATE_TOKEN`), and `auth` (`process.env.RESONATE_USERNAME`/`RESONATE_PASSWORD`).
- Documented defaults for `group` (`"default"`), `pid` (message source generated PID), `ttl` (`1 * util.MIN`), `verbose` (`false`), `encryptor` (`NoopEncryptor`), `tracer` (`NoopTracer`), `transport` (unset), and `prefix` (`process.env.RESONATE_PREFIX`).
- No runtime behavior was changed; this is a docs-only addition adjacent to the existing constructor signature.

### Testing
- No automated tests were executed for this change because it is documentation-only.
- Type checks and build were not run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_695d482b3684832bbf8b63b6fa5846ee)