### PR TITLE
docs: add DST badge, CLAUDE.md, and fix Twitter link

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file helps AI coding agents understand the resonate-sdk-ts repository.
+
+## What this repo is
+
+The Resonate TypeScript SDK (`@resonatehq/sdk`) lets developers write reliable, distributed applications using ordinary TypeScript generator functions. The SDK coordinates with the Resonate Server to persist function execution state, enabling long-running workflows that survive process restarts.
+
+## Build
+
+```shell
+npm install
+npm run build        # compiles TypeScript via tsc (output in dist/)
+npm run type-check   # type-check without emitting
+```
+
+Requires Node >= 22.
+
+## Test
+
+```shell
+npm test             # runs Jest (jest.config.js)
+npm run dst          # runs the deterministic simulation (sim/main.ts)
+```
+
+Individual test files live in `tests/`. The DST (deterministic simulation testing) lives in `sim/`.
+
+## Lint / Format
+
+```shell
+npm run check        # Biome linter check
+npm run check:fix    # Biome linter check with auto-fix
+npm run fmt          # Biome formatter
+```
+
+## Key directories
+
+| Path | Purpose |
+|------|---------|
+| `src/` | Core SDK source |
+| `src/resonate.ts` | Main `Resonate` class — entry point for users |
+| `src/context.ts` | `Context` type passed to every Resonate function |
+| `src/core.ts` | Execution engine |
+| `src/coroutine.ts` | Generator coroutine driver |
+| `src/promises.ts` | Durable promise primitives |
+| `src/schedules.ts` | Schedule API |
+| `src/tasks.ts` | Task polling and dispatch |
+| `src/network/` | HTTP networking (remote server communication) |
+| `src/processor/` | Task processor |
+| `tests/` | Jest unit and integration tests |
+| `sim/` | Deterministic simulation (DST) for chaos/reliability testing |
+| `dist/` | Compiled output (not committed) |
+
+## Key conventions
+
+- **Generator functions**: Resonate functions are TypeScript generator functions (`function*`). Yielding `context.run(...)` or `context.sleep(...)` creates durable checkpoints. This is the core programming model — do not convert them to async/await.
+- **`yield*` vs `yield`**: Use `yield*` with `context.run()` to properly delegate to sub-generators.
+- **Registration**: Functions must be registered with `resonate.register(fn)` before they can be invoked.
+- **Encoder**: Results are serialized via `src/encoder.ts`. Custom encoders can be provided.
+- **Options**: Per-call options (timeout, tags, retry policy) are set via `src/options.ts`.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the fork-and-branch workflow. PRs should be squash-merged.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![cicd](https://github.com/resonatehq/resonate-sdk-ts/actions/workflows/cicd.yaml/badge.svg)](https://github.com/resonatehq/resonate-sdk-ts/actions/workflows/cicd.yaml)
 [![codecov](https://codecov.io/gh/resonatehq/resonate-sdk-ts/branch/main/graph/badge.svg)](https://codecov.io/gh/resonatehq/resonate-sdk-ts)
+[![dst](https://github.com/resonatehq/resonate-sdk-ts/actions/workflows/dst.yml/badge.svg)](https://github.com/resonatehq/resonate-sdk-ts/actions/workflows/dst.yml)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## About this component
@@ -15,7 +16,7 @@ The Resonate TypeScript SDK enables developers to build reliable and scalable cl
 - [Example application library](https://github.com/resonatehq-examples)
 - [Join the Discord](https://resonatehq.io/discord)
 - [Subscribe to the Blog](https://journal.resonatehq.io/subscribe)
-- [Follow on Twitter](https://twitter.com/resonatehqio)
+- [Follow on X](https://x.com/resonatehqio)
 - [Follow on LinkedIn](https://www.linkedin.com/company/resonatehqio)
 - [Subscribe on YouTube](https://www.youtube.com/@resonatehqio)
 


### PR DESCRIPTION
## Summary

- Adds `[![dst](...)](...)` badge for the `dst.yml` workflow, placed after the existing cicd and codecov badges (closes #262)
- Adds `CLAUDE.md` to help AI coding agents understand the repo structure, build/test commands, key directories, and generator-function conventions (closes #360)
- Updates Twitter link to `x.com/resonatehqio` for consistency with other Resonate repos

## Test plan

- [ ] Verify DST badge renders correctly on the repo homepage
- [ ] Verify CLAUDE.md content is accurate against current `package.json` scripts and `src/` layout
- [ ] Verify the X link resolves correctly

References: https://github.com/resonatehq/resonatehq-workq/issues/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)