### PR TITLE
Remove unused Resonate server from CI and run on all PRs

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -22,11 +20,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.21
-
       - name: Checkout resonate-sdk-ts repository
         uses: actions/checkout@v4
 
@@ -39,23 +32,7 @@ jobs:
       - name: Run type check
         run: npm run type-check
 
-      - name: Checkout resonate repository
-        uses: actions/checkout@v4
-        with:
-          repository: resonatehq/resonate
-          path: resonate
-
-      - name: Build resonate
-        run: go build -o resonate
-        working-directory: resonate
-
-      - name: Start resonate server
-        run: ./resonate serve &
-        working-directory: resonate
-
       - name: Run tests
-        env:
-          RESONATE_STORE_URL: http://localhost:8001
         run: npm test -- --verbose
 
       - name: Upload coverage report to Codecov


### PR DESCRIPTION
The server was never actually used by the tests — all tests use LocalNetwork (in-memory) and the RESONATE_STORE_URL env var set in CI was never read by the SDK. Also removed the PR branch filter so the job runs on PRs targeting any branch.