### PR TITLE
next release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resonatehq/sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "TypeScript SDK for Resonate",
   "author": "Resonate Developers",
   "license": "Apache-2.0",

--- a/src/network/http.ts
+++ b/src/network/http.ts
@@ -403,7 +403,7 @@ export class PushMessageSource implements HttpAdapter {
   private logger?: Logger;
 
   constructor({
-    host = "0.0.0.0",
+    host = "127.0.0.1",
     port = 0,
     logger = undefined,
   }: {

--- a/tests/network/push.test.ts
+++ b/tests/network/push.test.ts
@@ -134,8 +134,8 @@ describe("PushMessageSource (via HttpNetwork)", () => {
     await network.init();
 
     // Both addresses should be set to the same HTTP URL with the resolved port
-    expect(network.unicast).toMatch(/^http:\/\/0\.0\.0\.0:\d+$/);
-    expect(network.anycast).toMatch(/^http:\/\/0\.0\.0\.0:\d+$/);
+    expect(network.unicast).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(network.anycast).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
     expect(network.unicast).toBe(network.anycast);
   });
 });


### PR DESCRIPTION
**Fix: `PushMessageSource` advertises an unroutable URL on macOS**

`PushMessageSource` defaulted to `host: "0.0.0.0"`, which it used both as the bind address *and* as the host in `unicast`/`anycast`. That conflates two different things:

- `0.0.0.0` is a valid **bind** address (wildcard — listen on all interfaces).
- `0.0.0.0` is **not** a valid **connect** address.

On Linux, the kernel papers over the difference by silently rewriting a `connect()` to `0.0.0.0` → `127.0.0.1`, so things "just work." On macOS (BSD sockets), it doesn't — `connect()` returns `EADDRNOTAVAIL`. That's why `tests/network/push.test.ts` passes in CI (Ubuntu) but fails locally on macOS with errors like:

```
connect EADDRNOTAVAIL 0.0.0.0:50619 - Local (127.0.0.1:50620)
```

It's also a latent correctness bug outside tests: the unicast/anycast URLs get sent to the Resonate server as the address it should push to, and `http://0.0.0.0:<port>` isn't reachable from anywhere.

**Change:** default `host` in `PushMessageSource` from `"0.0.0.0"` → `"127.0.0.1"`. Bind and advertised URL now both use a routable loopback address. Callers who actually want to listen on all interfaces can still pass `host: "0.0.0.0"` explicitly (and would presumably also configure a routable advertised host).

Test in `tests/network/push.test.ts` that pinned the URL format to `0.0.0.0` was updated to expect `127.0.0.1`. All 309 tests pass.
