### PR TITLE
context: document detached + recursive-tail forever-loop pattern

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -503,6 +503,45 @@ export class InnerContext implements Context {
     return new RFC(id, func, version, this.remoteCreateReq({ id, data, opts, breaksLineage: idChanged }));
   }
 
+  /**
+   * Spawns a workflow as a fresh root promise — independent execution lifecycle
+   * and independent replay scope (lineage break, new originId).
+   *
+   * Unlike `ctx.run` / `ctx.rpc`, the spawned workflow is not a child of the
+   * current invocation. It survives parent completion and replays in its own
+   * isolated scope.
+   *
+   * Use when:
+   * - Cross-service fire-and-forget where the parent does not wait for the result.
+   * - Background tasks that should outlive the parent invocation.
+   * - Bounded replay scope for long-running or forever-loop workflows: re-rooting
+   *   per logical unit of work caps the history each replay must walk.
+   *
+   * @example
+   * Forever-loop pattern — recursive tail call from inside the per-iteration function:
+   * ```ts
+   * // Each invocation plays exactly one game, then spawns the next as a fresh
+   * // root and returns. Replay scope is bounded to one game forever.
+   * function* playGame(ctx: Context, n: number) {
+   *   // ...play one game (ctx.run, ctx.sleep, etc.)...
+   *   yield* ctx.detached(playGame, n + 1); // last yield, then return
+   * }
+   * ```
+   *
+   * The split must happen *inside* the per-iteration function. A parent loop
+   * that calls `ctx.detached` repeatedly — `for (;;) yield* ctx.detached(work, n)`
+   * — still records each call in the parent's history via its sequence counter,
+   * reproducing the bug on the parent.
+   *
+   * Without this split, a forever loop in a single durable invocation
+   * accumulates child promises on every iteration. On cold-start, each replay
+   * re-walks the full history. Once replay duration exceeds the acquired-task
+   * lease, the server reassigns the task mid-execution (error code 1199) and
+   * cadence collapses.
+   *
+   * @returns An {@link RFI} handle. Optionally `yield*` it to await completion;
+   *   otherwise the spawned workflow runs independently of the caller.
+   */
   detached<F extends Func>(func: F, ...args: ParamsWithOptions<F>): RFI<Return<F>>;
   detached<T>(func: string, ...args: any[]): RFI<T>;
   detached(funcOrName: Func | string, ...args: any[]): RFI<any> {


### PR DESCRIPTION
## Summary
- Adds JSDoc on `Context#detached` covering the bounded-replay use case, not just fire-and-forget
- Documents the canonical recursive-tail pattern (per-iteration function spawns its successor via `ctx.detached` as its last yield, then returns)
- Calls out the parent-loop anti-pattern (`for (;;) yield* ctx.detached(...)`) — still records each call in the parent's history via `seqid`, reproducing the bug on the parent
- Names the failure mode the split prevents: replay > acquired-task lease → code 1199 → cadence collapse

## Why
Motivated by the chess-hero-server slow-burn collapse on 2026-05-05. After 8 days of `while(true) { playGame() }` inside a single durable invocation, ~10k accumulated child promises caused cold-start replay to exceed the `@resonatehq/gcp` default 5-min `ttl` on Cloud Functions. Server reassigned tasks mid-execution; cadence collapsed from 4.5s/move to 13–22 min/move.

The fix that shipped: https://github.com/resonatehq/chess-hero-server/commit/68eddff — `playGame` plays one game and `yield* ctx.detached(playGame, n + 1)` as its last yield. Lineage break → fresh originId → bounded replay scope.

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run check` (Biome) passes
- [ ] JSDoc renders correctly in IDE hover (manual check)

Companion PR on docs site: resonatehq/docs.resonatehq.io#193

🤖 Generated with [Claude Code](https://claude.com/claude-code)