### PR TITLE
nats optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
       "import": "./dist/async/index.js",
       "default": "./dist/async/index.js"
     },
+    "./nats": {
+      "types": "./dist/network/nats.d.ts",
+      "import": "./dist/network/nats.js",
+      "default": "./dist/network/nats.js"
+    },
     "./package.json": "./package.json"
   },
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ export { AsyncHeartbeat, NoopHeartbeat } from "./heartbeat.js";
 export { ConsoleLogger, type Logger, type LogLevel } from "./logger.js";
 export { type HttpAdapter, HttpNetwork, PollMessageSource } from "./network/http.js";
 export { LocalNetwork } from "./network/local.js";
-export { NatsNetwork, type NatsNetworkConfig } from "./network/nats.js";
 export type { Network, Recv, Send } from "./network/network.js";
 export * from "./network/types.js";
 export { OptionsBuilder } from "./options.js";

--- a/src/network/nats.ts
+++ b/src/network/nats.ts
@@ -1,7 +1,7 @@
-import { randomUUID } from "node:crypto";
 import type { Msg, MsgHdrs, NatsConnection, Subscription } from "@nats-io/transport-node";
 import { ResonateTimeoutException } from "../exceptions.js";
 import type { Logger } from "../logger.js";
+import { randomUUID } from "../platform.js";
 import type { Network } from "./network.js";
 import { isMessage, isResponse, type Message, type Request, type Response } from "./types.js";
 


### PR DESCRIPTION
## Why

The default entry point (`@resonatehq/sdk`) must be browser-compatible. The NATS network depends on `@nats-io/transport-node` and `node:crypto`, both Node-only. As long as `NatsNetwork` was re-exported from `src/index.ts`, bundlers pulled these Node modules into every build — breaking the SDK in the browser.

## What

- Drop the `NatsNetwork` / `NatsNetworkConfig` re-export from `src/index.ts` so the default build no longer references any Node-only NATS code.
- Expose NATS through a separate `@resonatehq/sdk/nats` subpath export for the Node users who need it — opt-in instead of default.
- Replace `node:crypto`'s `randomUUID` with the platform abstraction (`../platform.js`) inside `nats.ts`, keeping it consistent with the rest of the codebase.

## Impact

Existing NATS users update their import path. No API changes.

Before (no longer works):

```ts
import { NatsNetwork } from "@resonatehq/sdk";
```

After — import from the dedicated subpath (Node-only, requires `@nats-io/transport-node`):

```ts
import { NatsNetwork, type NatsNetworkConfig } from "@resonatehq/sdk/nats";
```
