### PR TITLE
test(localnet): enforce the server's schedule-create target validation

### DIFF
--- a/src/network/local.ts
+++ b/src/network/local.ts
@@ -1009,6 +1009,16 @@ export class Server {
   }
 
   private scheduleCreate(now: number, req: ScheduleCreateReq): { response: ScheduleCreateRes; changes: Change[] } {
+    // Mirror the server's create-time validation: every fired promise needs a
+    // routing target, so a schedule whose promiseTags lack resonate:target is
+    // rejected up front (same status and message as the real server).
+    if (!req.data.promiseTags || !("resonate:target" in req.data.promiseTags)) {
+      return {
+        response: this.response("schedule.create", 400, "promiseTags must include a resonate:target tag"),
+        changes: [],
+      };
+    }
+
     const existingSchedule = this.schedules.get(req.data.id);
     if (existingSchedule) {
       return {

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -330,6 +330,30 @@ describe("Resonate usage tests", () => {
     await resonate.stop();
   });
 
+  test("schedule create without resonate:target is rejected", async () => {
+    // The local network enforces the server's create-time validation.
+    const resonate = new Resonate({ pid: "default", ttl: Number.MAX_SAFE_INTEGER });
+
+    await expect(
+      resonate.schedules.create("untagged-schedule", "* * * * *", "untagged.{{.timestamp}}", 60_000),
+    ).rejects.toThrow("promiseTags must include a resonate:target tag");
+
+    await resonate.stop();
+  });
+
+  test("schedule stamps resonate:target on the schedule record", async () => {
+    const resonate = new Resonate({ pid: "default", ttl: Number.MAX_SAFE_INTEGER });
+
+    const scheduleId = `tagged-schedule-${crypto.randomUUID().replace(/-/g, "")}`;
+    const schedule = await resonate.schedule(scheduleId, "0 * * * *", "someFunc");
+
+    const record = await resonate.schedules.get(scheduleId);
+    expect(record.promiseTags["resonate:target"]).toBeDefined();
+
+    await schedule.delete();
+    await resonate.stop();
+  });
+
   test("concurrent execution must be concurrent", async () => {
     const resonate = new Resonate({ pid: "default", ttl: Number.MAX_SAFE_INTEGER });
 


### PR DESCRIPTION
Fixes #547.

The in-process `LocalNetwork` accepted `schedule.create` with empty `promiseTags`, while the real server rejects it — so schedule unit tests could stay green on a create the server refuses. (The high-level `.schedule()` in this SDK already injects `resonate:target`, so nothing here changes runtime behavior — this closes the test-fidelity gap.)

## Changes

- `LocalNetwork.scheduleCreate` rejects requests whose `promiseTags` lack `resonate:target`, with the server's exact status and message: `400 promiseTags must include a resonate:target tag`.
- New tests: an untagged low-level `schedules.create` rejects with that message; the high-level `.schedule()` record carries `resonate:target`.

Same change, applied per-SDK: Python resonatehq/resonate-sdk-py#454, Rust (see resonatehq/resonate-sdk-rs#47).

## Verification

Full suite green (435 passed, 1 pre-existing skip), `tsc --noEmit` and biome clean. The mirrored server behavior was reproduced against a live server: create without the tag → `400 promiseTags must include a resonate:target tag`; with it → 200.