### PR TITLE
Mark latent promises external

### DIFF
--- a/src/async/context.ts
+++ b/src/async/context.ts
@@ -739,6 +739,16 @@ export class AsyncContext implements Context {
         "resonate:origin": this.originId,
         // Prefix is set at the top and propagates down unchanged forever.
         "resonate:prefix": this.prefixId,
+        // A latent promise has no function behind it: nothing inside the
+        // system can ever settle it, only an out-of-band actor calling
+        // `promises.resolve`. That is the definition of an external promise,
+        // and marking it so is what entitles it to an armed timeout and to
+        // having awaiters at all — a server implementing the specification
+        // refuses a callback on a promise that is not external, because an
+        // internal promise's deadline is projection-only and its awaiter
+        // could be stranded forever. Placed before the caller's tags so an
+        // explicit tag still wins.
+        "resonate:external": "true",
         ...tags,
       },
     });

--- a/src/context.ts
+++ b/src/context.ts
@@ -761,6 +761,13 @@ export class InnerContext implements Context {
           // Prefix is set at the top and propagates down unchanged forever,
           // independent of origin (which detached/explicit-id may break).
           "resonate:prefix": this.prefixId,
+          // A latent promise has no function behind it: only an out-of-band
+          // actor calling `promises.resolve` can ever settle it, which is the
+          // definition of an external promise. Marking it so is what entitles
+          // it to an armed timeout and to having awaiters — a server
+          // implementing the specification refuses a callback on a promise
+          // that is not external. Before the caller's tags, so theirs win.
+          "resonate:external": "true",
           ...tags,
         },
       },

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -442,11 +442,43 @@ describe("Resonate usage tests", () => {
     expect(await h.result()).toBe("myValue");
     expect((await resonate.promises.get("hitl-1.0")).tags).toEqual({
       "resonate:branch": "hitl-1.0",
+      "resonate:external": "true",
       "resonate:origin": "hitl-1",
       "resonate:prefix": "hitl-1",
       "resonate:parent": "hitl-1",
       "resonate:scope": "global",
     });
+  });
+
+  test("A latent promise is external, and a caller's tags still win", async () => {
+    resonate = new Resonate({ group: "default", pid: "0", ttl: 50_000 });
+
+    // Nothing inside the system can settle a latent promise — only an
+    // out-of-band `promises.resolve`. The specification lets only external
+    // promises have awaiters and carry an armed timeout (an internal promise's
+    // deadline is projection-only, so its awaiter could be stranded), so a
+    // server implementing that rule refuses to register a callback against an
+    // untagged one. Awaiting the promise below is the whole point of the API,
+    // so it has to be marked.
+    const wf = async (ctx: Context): Promise<[string, string]> => {
+      const plain = ctx.promise<string>();
+      const tagged = ctx.promise<string>({ tags: { mine: "yes" } });
+      return [await plain, await tagged];
+    };
+    resonate.register("extwf", wf);
+
+    const h = await resonate.run("ext-1", wf);
+    await sleep(100);
+
+    expect((await resonate.promises.get("ext-1.0")).tags["resonate:external"]).toBe("true");
+
+    const withOwn = (await resonate.promises.get("ext-1.1")).tags;
+    expect(withOwn["resonate:external"]).toBe("true");
+    expect(withOwn.mine).toBe("yes"); // a caller's own tags are not clobbered
+
+    await resonate.promises.resolve("ext-1.0", { data: codec.encode("a").data });
+    await resonate.promises.resolve("ext-1.1", { data: codec.encode("b").data });
+    expect(await h.result()).toEqual(["a", "b"]);
   });
 
   test("Correctly sets timeout", async () => {
@@ -469,6 +501,7 @@ describe("Resonate usage tests", () => {
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
       "resonate:branch": "timeout-1.0",
+      "resonate:external": "true",
       "resonate:origin": "timeout-1",
       "resonate:prefix": "timeout-1",
       "resonate:parent": "timeout-1",

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -551,6 +551,7 @@ describe("Resonate usage tests", () => {
     await resonate.stop();
     expect((await resonate.promises.get("f.0")).tags).toEqual({
       "resonate:branch": "f.0",
+      "resonate:external": "true",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -576,6 +577,7 @@ describe("Resonate usage tests", () => {
     await resonate.stop();
     expect((await resonate.promises.get("f.0")).tags).toEqual({
       "resonate:branch": "f.0",
+      "resonate:external": "true",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -603,6 +605,7 @@ describe("Resonate usage tests", () => {
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
       "resonate:branch": "f.0",
+      "resonate:external": "true",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",


### PR DESCRIPTION
`ctx.promise()` creates a promise with no function behind it — the documented human-in-the-loop primitive. Nothing inside the system can settle it; only an out-of-band `promises.resolve` can. That is the definition of an external promise, but the tag was not being set.

## Why it matters

The specification lets **only external promises have awaiters**, because only they carry an armed durable timeout:

```lean
-- spec/01-objects/state.lean
/-- External promises — explicitly tagged `resonate:external = "true"`,
    targeted, or timers — may have awaiters and carry an armed (durable)
    timeout; the timeout transition guarantees their awaiters are never
    stranded. Internal promises must not have awaiters; their deadlines
    are projection-only. -/
def PromiseObject.external (p : PromiseObject) : Bool :=
  p.tags.get? "resonate:external" == some "true"
    || p.tags.has "resonate:target" || p.isTimer
```

```lean
-- spec/02-actions/P-04-promise.register_callback.lean
if !pAwaited.external then
  return { status := 422 }
```

So on a server implementing P-04, awaiting a latent promise is refused — and awaiting it is the entire point of the API. `sleep` already tags `resonate:timer` for exactly this reason; the latent path was the gap.

## How it was found

Building human-in-the-loop on [resonate-on-convex](https://github.com/resonatehq/resonate-on-convex), whose component enforces P-04. The bundled `LocalNetwork` does **not** enforce the rule — `promiseRegisterCallback` there only checks that awaited ≠ awaiter — which is why the SDK's own suite never caught this.

That gap is worth a separate look: the reference server diverging from the specification means any conformance issue like this stays invisible in-repo. Not addressed here.

## The change

One line per engine, in the latent create path only:

- `src/async/context.ts` — `latentCreateReq`
- `src/context.ts` — `latentCreateOpts`

Each helper has exactly one caller, `promise()`. `detached()` goes through `detachedCreateReq` / `remoteCreateReq` and is unaffected — a detached workflow is a real targeted workflow, not an external promise.

The tag is placed **before** the caller's `...tags` spread, so an explicit tag still wins.

## Tests

- Three existing tag assertions updated (`tests/resonate.test.ts`, `tests/async/resonate.test.ts`) — these are the only places that pinned the exact tag set of a latent promise.
- One new named test covering both the property and the precedence, so the tag cannot be dropped silently:

```ts
expect((await resonate.promises.get("ext-1.0")).tags["resonate:external"]).toBe("true");

const withOwn = (await resonate.promises.get("ext-1.1")).tags;
expect(withOwn["resonate:external"]).toBe("true");
expect(withOwn.mine).toBe("yes"); // a caller's own tags are not clobbered
```

`npm test` 436 passing, `npm run type-check` clean, `npm run check` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Eo5MzppTGcXPzrTf2a9Zey)_