### PR TITLE
feat: promise id lineage separator '.' -> ':'

### DIFF
--- a/examples/async/human-in-the-loop.ts
+++ b/examples/async/human-in-the-loop.ts
@@ -67,7 +67,7 @@ async function cancelOrder(_info: Info, orderId: string, note: string): Promise<
 // -- Orchestrator ---------------------------------------------------------
 
 async function fulfillOrder(ctx: Context, orderId: string, amount: number): Promise<string> {
-  // Open the human-decision promise first. Its `.id` (`{workflowId}.0`) is
+  // Open the human-decision promise first. Its `.id` (`{workflowId}:0`) is
   // available synchronously -- the address to resolve.
   const approval = ctx.promise<Decision>();
   await ctx.run(notifyReviewer, orderId, amount, approval.id);

--- a/examples/async/structured-concurrency.ts
+++ b/examples/async/structured-concurrency.ts
@@ -13,8 +13,8 @@
 // spawned is still in flight. Before foo's promise resolves, the runtime joins
 // both children.
 //
-// We prove it durably. Children get deterministic ids `{foo_id}.0` and
-// `{foo_id}.1`. After foo returns 5 we attach to those two promises by id and
+// We prove it durably. Children get deterministic ids `{foo_id}:0` and
+// `{foo_id}:1`. After foo returns 5 we attach to those two promises by id and
 // assert each resolved -- evidence the never-awaited work was awaited *by the
 // runtime* on our behalf.
 //
@@ -50,12 +50,12 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order as `{parent}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/examples/generator/human-in-the-loop.ts
+++ b/examples/generator/human-in-the-loop.ts
@@ -71,7 +71,7 @@ async function cancelOrder(_ctx: Context, orderId: string, note: string): Promis
 
 function* fulfillOrder(ctx: Context, orderId: string, amount: number): Generator<any, string, any> {
   // Open the human-decision promise first so its id is deterministic
-  // (`{workflowId}.0`). The Future's `.id` is the address to resolve.
+  // (`{workflowId}:0`). The Future's `.id` is the address to resolve.
   const approval = yield* ctx.promise<Decision>();
   const approvalId = approval.id;
 

--- a/examples/generator/structured-concurrency.ts
+++ b/examples/generator/structured-concurrency.ts
@@ -12,7 +12,7 @@
 // flight. Before foo's promise resolves, the runtime joins both children.
 //
 // We prove it durably. `ctx.beginRun` children get deterministic ids
-// `{foo_id}.0` and `{foo_id}.1`. After foo returns 5 we attach to those two
+// `{foo_id}:0` and `{foo_id}:1`. After foo returns 5 we attach to those two
 // promises by id and assert each resolved -- evidence the never-awaited work
 // was awaited *by the runtime* on our behalf.
 //
@@ -48,12 +48,12 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order as `{parent}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/src/async/context.ts
+++ b/src/async/context.ts
@@ -88,7 +88,7 @@ export interface Context extends Info {
    * Creates a latent durable promise (DPC) with no associated function, intended
    * to be resolved out of band (human-in-the-loop / external signal) via
    * `resonate.promises.resolve(id)`. Awaiting it suspends the parent until the
-   * promise is settled externally. The id is `${ctx.id}.${seq}`.
+   * promise is settled externally. The id is `${ctx.id}:${seq}` (or `.${seq}` when nested).
    */
   promise<T>(opts?: { timeout?: number; data?: any; tags?: { [key: string]: string } }): DurablePromise<T>;
 
@@ -762,7 +762,12 @@ export class AsyncContext implements Context {
   }
 
   private seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // `<promiseId>:<lineage>`: a single `:` separates the promiseId (lineage
+    // origin) from the lineage, and `.` separates lineage segments. The first
+    // segment minted off a bare promiseId (id === originId) uses `:`
+    // (`root` -> `root:1`); deeper segments use `.` (`root:1` -> `root:1.1`).
+    const sep = this.id === this.originId ? ":" : ".";
+    return `${this.id}${sep}${this.seq}`;
   }
 }
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -324,7 +324,7 @@ export class InnerContext implements Context {
     // (resonate.run/rpc) and propagated down unchanged forever -- through every
     // child AND across detached re-roots -- never tracking the (diverging)
     // lineage origin. Bounds recursive detached ids: each level mints
-    // `${prefixId}.d${hash}` off this fixed prefix. Mirrors the Python SDK's
+    // `${prefixId}:d${hash}` off this fixed prefix. Mirrors the Python SDK's
     // `Context.prefix_id`.
     this.prefixId = prId;
     this.branchId = bId;
@@ -596,7 +596,7 @@ export class InnerContext implements Context {
       // detached ids stay bounded NOT via origin but via resonate:prefix, which
       // is propagated down unchanged (set in remoteCreateReq = this.prefixId) and
       // is what `util.detachedId(this.prefixId, ...)` roots the id on. So each
-      // level mints `${prefix}.d${hash}` off the same fixed prefix instead of
+      // level mints `${prefix}:d${hash}` off the same fixed prefix instead of
       // off its own grown id. Mirrors the Python SDK (detached origin = its id,
       // prefix carried forward).
       this.remoteCreateReq({ id, data, opts, maxTimeout: Number.MAX_SAFE_INTEGER, breaksLineage: true }),
@@ -794,6 +794,11 @@ export class InnerContext implements Context {
   }
 
   seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // `<promiseId>:<lineage>`: a single `:` separates the promiseId (lineage
+    // origin) from the lineage, and `.` separates lineage segments. The first
+    // segment minted off a bare promiseId (id === originId) uses `:`; deeper
+    // segments use `.` (`root:1` -> `root:1.1`).
+    const sep = this.id === this.originId ? ":" : ".";
+    return `${this.id}${sep}${this.seq}`;
   }
 }

--- a/src/network/nats.ts
+++ b/src/network/nats.ts
@@ -32,10 +32,10 @@ const REPLY_HEADER = "Resonate-Reply-To";
 // ROUTING HELPERS
 // =============================================================================
 
-// Return the lineage origin: the substring before the first `.`.
+// Return the lineage origin (promiseId): the substring before the first `:`.
 function idToOrigin(id: string): string {
-  const dot = id.indexOf(".");
-  return dot === -1 ? id : id.slice(0, dot);
+  const sep = id.indexOf(":");
+  return sep === -1 ? id : id.slice(0, sep);
 }
 
 // Derive the routing origin from a request, mirroring the server's client.

--- a/src/util.ts
+++ b/src/util.ts
@@ -113,11 +113,12 @@ function cyrb53(input: string | Uint8Array, seed = 0): number {
 }
 
 export function detachedId(prefix: string, seqid: string): string {
-  // `${prefix}.d${hash}` -- the `d` marks the segment as a detached child (vs an
-  // rfi child's numeric `.${seq}`). `prefix` is the id-generation prefix
-  // (resonate:prefix), set once at the top and propagated down unchanged, so
-  // recursive detached ids stay bounded at one segment past the prefix.
-  return `${prefix}.d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
+  // `${prefix}:d${hash}` -- the `:` is the promiseId->lineage boundary and the
+  // `d` marks the segment as a detached child (vs an rfi child's numeric
+  // `:${seq}`). `prefix` is the id-generation prefix (resonate:prefix), set once
+  // at the top and propagated down unchanged, so recursive detached ids stay
+  // bounded at one segment past the prefix.
+  return `${prefix}:d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
 }
 
 export function getCallerInfo(): string {

--- a/tests/async/async-trace.test.ts
+++ b/tests/async/async-trace.test.ts
@@ -165,14 +165,14 @@ describe("async engine lifecycle trace", () => {
     // Root spawn is first.
     expect(t[0]).toEqual({ kind: "spawn", id: "main" });
 
-    // run main -> main.0
+    // run main -> main:0
     const run = t.find((e) => e.kind === "run");
-    expect(run).toEqual({ kind: "run", id: "main", callee: "main.0" });
+    expect(run).toEqual({ kind: "run", id: "main", callee: "main:0" });
 
     // Child spawns once and returns 7.
     expect(counts(t).spawn.filter((e) => e.id !== "main").length).toBe(1);
-    const childReturn = t.find((e) => e.kind === "return" && e.id === "main.0");
-    expect(childReturn).toEqual({ kind: "return", id: "main.0", state: "resolved", value: 7 });
+    const childReturn = t.find((e) => e.kind === "return" && e.id === "main:0");
+    expect(childReturn).toEqual({ kind: "return", id: "main:0", state: "resolved", value: 7 });
 
     // Root return is last.
     expect(t[t.length - 1]).toEqual({ kind: "return", id: "main", state: "resolved", value: 7 });
@@ -237,7 +237,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.state).toBe("rejected");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn.kind === "return" && rootReturn.state).toBe("rejected");
@@ -264,7 +264,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.value).toBe("caught:kaboom");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn).toMatchObject({ kind: "return", id: "main", state: "resolved" });
@@ -279,12 +279,12 @@ describe("async engine lifecycle trace", () => {
     const res = await runRoot(fns, "main");
 
     expect(res.kind).toBe("suspended");
-    if (res.kind === "suspended") expect(res.awaited).toEqual(["main.0"]);
+    if (res.kind === "suspended") expect(res.awaited).toEqual(["main:0"]);
     const t = res.trace;
 
     expect(t[0]).toEqual({ kind: "spawn", id: "main" });
-    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main.0" });
-    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main.0" });
+    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main:0" });
+    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main:0" });
     expect(t[t.length - 1]).toEqual({ kind: "suspend", id: "main" });
 
     expectLifecycleWellFormed(t);
@@ -353,9 +353,9 @@ describe("async engine lifecycle trace", () => {
       const core = newCore(registryOf(fns), network);
       const { task, promise, preload } = await seedRoot(network, "main", "main", []);
 
-      // Pre-settle the child (main.0) so the engine's create dedups against it.
+      // Pre-settle the child (main:0) so the engine's create dedups against it.
       const effects = util.buildEffects(network.send, codec, { id: task.id, version: task.version });
-      await presettle(effects, "main.0", 99);
+      await presettle(effects, "main:0", 99);
 
       const res = await core.executeUntilBlocked(task, promise, preload);
 
@@ -363,10 +363,10 @@ describe("async engine lifecycle trace", () => {
       if (res.kind === "done") expect(res.value).toBe(99); // deduped to the stored value
 
       const c = counts(res.trace);
-      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main.0" }]);
+      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main:0" }]);
       expect(c.dedup.length).toBe(1);
-      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main.0", state: "resolved" });
-      expect(c.spawn.filter((e) => e.id === "main.0").length).toBe(0); // deduped, never spawned
+      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main:0", state: "resolved" });
+      expect(c.spawn.filter((e) => e.id === "main:0").length).toBe(0); // deduped, never spawned
 
       expectLifecycleWellFormed(res.trace);
     } finally {

--- a/tests/async/async.test.ts
+++ b/tests/async/async.test.ts
@@ -174,8 +174,8 @@ describe("Resonate — async/await engine", () => {
 
     await (await resonate.run("createorder", fanout)).result();
 
-    const children = recording.creates.filter((id) => id.startsWith("createorder."));
-    expect(children).toEqual(["createorder.0", "createorder.1", "createorder.2", "createorder.3"]);
+    const children = recording.creates.filter((id) => id.startsWith("createorder:"));
+    expect(children).toEqual(["createorder:0", "createorder:1", "createorder:2", "createorder:3"]);
   });
 
   test("hang model: a suspending pass never enters the surrounding try/catch", async () => {
@@ -286,8 +286,8 @@ describe("Resonate — async/await engine", () => {
     resonate.register("dpcwf", wf);
 
     const handle = await resonate.run("dpc-1", wf);
-    await sleep(100); // ensure the latent promise dpc-1.0 has been created
-    await resonate.promises.resolve("dpc-1.0", { data: codec.encode("signal").data });
+    await sleep(100); // ensure the latent promise dpc-1:0 has been created
+    await resonate.promises.resolve("dpc-1:0", { data: codec.encode("signal").data });
 
     expect(await handle.result()).toBe("signal");
   });
@@ -323,10 +323,10 @@ describe("Resonate — async/await engine", () => {
     await (await resonate.run("prefix-1", wf)).result();
 
     expect(recording.tags.get("prefix-1")?.["resonate:prefix"]).toBe("prefix-1"); // root
-    expect(recording.tags.get("prefix-1.0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
-    expect(recording.tags.get("prefix-1.1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
-    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1.d"));
-    expect(detachedId).toMatch(/^prefix-1\.d[0-9a-f]{14}$/);
+    expect(recording.tags.get("prefix-1:0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
+    expect(recording.tags.get("prefix-1:1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
+    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1:d"));
+    expect(detachedId).toMatch(/^prefix-1:d[0-9a-f]{14}$/);
     expect(recording.tags.get(detachedId as string)?.["resonate:prefix"]).toBe("prefix-1");
   });
 
@@ -352,8 +352,8 @@ describe("Resonate — async/await engine", () => {
     // Every level keeps the top-level root as its id-generation prefix, so each
     // detached id is exactly one `.d` segment past it — bounded at any depth.
     for (const s of seen) expect(s.prefixId).toBe("nest-root");
-    expect(seen[1].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
-    expect(seen[2].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
+    expect(seen[1].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
+    expect(seen[2].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
     // The detached re-root breaks lineage: origin resets to its own id.
     expect(seen[1].originId).toBe(seen[1].id);
   });
@@ -420,7 +420,7 @@ describe("Resonate — async/await engine", () => {
 
     // Neither the root nor the (created) child promise settles.
     expect((await resonate.promises.get("panic-3")).state).toBe("pending");
-    expect((await resonate.promises.get("panic-3.0")).state).toBe("pending");
+    expect((await resonate.promises.get("panic-3:0")).state).toBe("pending");
   });
 
   test("ctx.panic(false) and ctx.assert(true) do not abort", async () => {

--- a/tests/async/core.test.ts
+++ b/tests/async/core.test.ts
@@ -212,16 +212,16 @@ describe("AsyncCore", () => {
 
       expect(res.kind).toBe("suspended");
       if (res.kind === "suspended") {
-        expect(res.awaited).toContain("p4.0");
-        expect(res.awaited).toContain("p4.1");
+        expect(res.awaited).toContain("p4:0");
+        expect(res.awaited).toContain("p4:1");
       }
 
       const suspend = sent.find((r) => r.kind === "task.suspend");
       expect(suspend).toBeDefined();
       if (suspend && suspend.kind === "task.suspend") {
         const awaitedIds = suspend.data.actions.map((a) => a.data.awaited);
-        expect(awaitedIds).toContain("p4.0");
-        expect(awaitedIds).toContain("p4.1");
+        expect(awaitedIds).toContain("p4:0");
+        expect(awaitedIds).toContain("p4:1");
       }
     });
 
@@ -244,7 +244,7 @@ describe("AsyncCore", () => {
           await origFn({
             kind: "promise.settle",
             head: { corrId: randomUUID(), version: VERSION },
-            data: { id: "p5.0", state: "resolved", value: codec.encode(7) },
+            data: { id: "p5:0", state: "resolved", value: codec.encode(7) },
           });
           return {
             kind: "task.suspend",
@@ -357,7 +357,7 @@ describe("AsyncCore", () => {
       const fence = creates[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-1.0");
+      expect(fence.data.action.data.id).toBe("fence-1:0");
 
       // Ensure no bare promise.create was sent during execution
       expect(sent.some((r) => r.kind === "promise.create")).toBe(false);
@@ -380,7 +380,7 @@ describe("AsyncCore", () => {
       const fence = settles[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-2.0");
+      expect(fence.data.action.data.id).toBe("fence-2:0");
 
       // No bare promise.settle should have been sent during execution
       expect(sent.some((r) => r.kind === "promise.settle")).toBe(false);

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -100,11 +100,11 @@ describe("Resonate usage tests", () => {
   test("test lineage rfc", async () => {
     resonate = newResonate();
     const baz = async (_info: Info): Promise<string> => {
-      // origin: foo.1 / parent: foo.1.0 / branch: foo.1.0.0
+      // origin: foo.1 / parent: foo.1:0 / branch: foo.1:0.0
       return "hello";
     };
     const bar = async (ctx: Context): Promise<string> => {
-      // origin: foo.1 / parent: foo.1 / branch: foo.1.0
+      // origin: foo.1 / parent: foo.1 / branch: foo.1:0
       return ctx.rpc<string>("baz");
     };
     const foo = async (ctx: Context): Promise<string> => {
@@ -124,19 +124,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
+      "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+      "resonate:branch": "foo.1:0.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -158,18 +158,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
     });
   });
@@ -185,8 +185,8 @@ describe("Resonate usage tests", () => {
     const h = await resonate.run("done-1", wf);
     expect(await h.done()).toBe(false);
 
-    await sleep(100); // ensure the latent promise done-1.0 exists
-    await resonate.promises.resolve("done-1.0", { data: codec.encode("v").data });
+    await sleep(100); // ensure the latent promise done-1:0 exists
+    await resonate.promises.resolve("done-1:0", { data: codec.encode("v").data });
     expect(await h.result()).toBe("v");
     expect(await h.done()).toBe(true);
 
@@ -349,15 +349,15 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("opts-1.0");
+      expect(fu.id).toBe("opts-1:0");
       return fu;
     };
     resonate.register("optswf", wf);
 
     const v = await res(resonate.run("opts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("opts-1.0");
-    expect(durable.id).toBe("opts-1.0");
+    const durable = await resonate.promises.get("opts-1:0");
+    expect(durable.id).toBe("opts-1:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
   });
 
@@ -370,15 +370,15 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function");
-      expect(fu.id).toBe("noopts-1.0");
+      expect(fu.id).toBe("noopts-1:0");
       return fu;
     };
     resonate.register("nooptswf", wf);
 
     const v = await res(resonate.run("noopts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("noopts-1.0");
-    expect(durable.id).toBe("noopts-1.0");
+    const durable = await resonate.promises.get("noopts-1:0");
+    expect(durable.id).toBe("noopts-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "noopts-1",
@@ -400,7 +400,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await res(resonate.rpc(`t${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`t${i}`);
-      const p2 = await resonate.promises.get(`t${i}.0`);
+      const p2 = await resonate.promises.get(`t${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -418,7 +418,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await res(resonate.rpc(`u${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`u${i}`);
-      const p2 = await resonate.promises.get(`u${i}.0`);
+      const p2 = await resonate.promises.get(`u${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -430,18 +430,18 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>();
-      expect(fu.id).toBe("hitl-1.0");
+      expect(fu.id).toBe("hitl-1:0");
       return fu;
     };
     resonate.register("hitlwf", wf);
 
     const h = await resonate.run("hitl-1", wf);
-    await sleep(100); // ensure hitl-1.0 promise is created
+    await sleep(100); // ensure hitl-1:0 promise is created
 
-    await resonate.promises.resolve("hitl-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("hitl-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
-    expect((await resonate.promises.get("hitl-1.0")).tags).toEqual({
-      "resonate:branch": "hitl-1.0",
+    expect((await resonate.promises.get("hitl-1:0")).tags).toEqual({
+      "resonate:branch": "hitl-1:0",
       "resonate:origin": "hitl-1",
       "resonate:prefix": "hitl-1",
       "resonate:parent": "hitl-1",
@@ -456,25 +456,25 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("timeout-1.0");
+      expect(fu.id).toBe("timeout-1:0");
       return fu;
     };
     resonate.register("timeoutwf", wf);
 
     const h = await resonate.run("timeout-1", wf);
-    await sleep(100); // ensure timeout-1.0 promise is created
+    await sleep(100); // ensure timeout-1:0 promise is created
 
-    const durable = await resonate.promises.get("timeout-1.0");
+    const durable = await resonate.promises.get("timeout-1:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "timeout-1.0",
+      "resonate:branch": "timeout-1:0",
       "resonate:origin": "timeout-1",
       "resonate:prefix": "timeout-1",
       "resonate:parent": "timeout-1",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("timeout-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("timeout-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
   });
 
@@ -489,12 +489,12 @@ describe("Resonate usage tests", () => {
     resonate.register("sleepwf", wf);
 
     const h = await resonate.run("sleep-1", wf);
-    await sleep(100); // ensure sleep-1.0 promise is created
+    await sleep(100); // ensure sleep-1:0 promise is created
 
-    const durable = await resonate.promises.get("sleep-1.0");
+    const durable = await resonate.promises.get("sleep-1:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "sleep-1.0",
+      "resonate:branch": "sleep-1:0",
       "resonate:origin": "sleep-1",
       "resonate:prefix": "sleep-1",
       "resonate:parent": "sleep-1",
@@ -581,11 +581,11 @@ describe("Resonate usage tests", () => {
     resonate.register("twf1", wf);
 
     await res(resonate.run("tdef-1", wf));
-    const durable = await resonate.promises.get("tdef-1.0");
-    expect(durable.id).toBe("tdef-1.0");
+    const durable = await resonate.promises.get("tdef-1:0");
+    expect(durable.id).toBe("tdef-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "tdef-1.0",
+      "resonate:branch": "tdef-1:0",
       "resonate:parent": "tdef-1",
       "resonate:origin": "tdef-1",
       "resonate:prefix": "tdef-1",
@@ -604,10 +604,10 @@ describe("Resonate usage tests", () => {
     resonate.register("twf2", wf);
 
     await res(resonate.run("topt-1", wf));
-    const durable = await resonate.promises.get("topt-1.0");
+    const durable = await resonate.promises.get("topt-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "topt-1.0",
+      "resonate:branch": "topt-1:0",
       "resonate:parent": "topt-1",
       "resonate:origin": "topt-1",
       "resonate:prefix": "topt-1",
@@ -626,10 +626,10 @@ describe("Resonate usage tests", () => {
     resonate.register("twf3", wf);
 
     await res(resonate.run("turl-1", wf));
-    const durable = await resonate.promises.get("turl-1.0");
+    const durable = await resonate.promises.get("turl-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "turl-1.0",
+      "resonate:branch": "turl-1:0",
       "resonate:parent": "turl-1",
       "resonate:origin": "turl-1",
       "resonate:prefix": "turl-1",
@@ -830,7 +830,7 @@ describe("Resonate usage tests", () => {
     // awaited out of band by id.
     expect(new Set(ids).size).toBe(2);
     for (const id of ids) {
-      expect(id).toMatch(/^equiv-1\.d[0-9a-f]+$/);
+      expect(id).toMatch(/^equiv-1:d[0-9a-f]+$/);
       expect(await (await resonate.get<string>(id)).result()).toBe("bar");
     }
   });

--- a/tests/async/structured-concurrency.test.ts
+++ b/tests/async/structured-concurrency.test.ts
@@ -127,8 +127,8 @@ describe("async engine structured concurrency", () => {
       expect(status.kind).toBe("done");
       if (status.kind !== "done") return;
       expect(status.value).toBe("done");
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire.0");
-      const rec = await getPromise(network, "sc-fire.0");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire:0");
+      const rec = await getPromise(network, "sc-fire:0");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("side-effect");
     } finally {
@@ -142,10 +142,10 @@ describe("async engine structured concurrency", () => {
       const leafA = async (_i: Info) => "a";
       const leafB = async (_i: Info, x: string) => `b:${x}`;
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-local.0 — pending remote, ends the pass
+        const timer = ctx.sleep(60_000); // sc-local:0 — pending remote, ends the pass
         const chained = (async () => {
-          const x = await ctx.run<string>("leafA"); // sc-local.1
-          return ctx.run<string>("leafB", x); // sc-local.2 — starts mid-drain
+          const x = await ctx.run<string>("leafA"); // sc-local:1
+          return ctx.run<string>("leafB", x); // sc-local:2 — starts mid-drain
         })();
         await Promise.all([timer, chained]);
         return "done";
@@ -156,13 +156,13 @@ describe("async engine structured concurrency", () => {
       // The pass suspends on the timer only; the chained locals both completed.
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-local.0"]);
+      expect(status.awaited).toEqual(["sc-local:0"]);
 
       // The chained run finished INSIDE the pass: its return event is in the
       // trace (not emitted after getTrace) and its durable promise is settled
       // before executeUntilBlocked returned (no settle racing task.suspend).
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local.2");
-      const rec = await getPromise(network, "sc-local.2");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local:2");
+      const rec = await getPromise(network, "sc-local:2");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("b:a");
     } finally {
@@ -175,10 +175,10 @@ describe("async engine structured concurrency", () => {
     try {
       const leafA = async (_i: Info) => "a";
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-remote.0
+        const timer = ctx.sleep(60_000); // sc-remote:0
         const chained = (async () => {
-          await ctx.run<string>("leafA"); // sc-remote.1
-          return ctx.rpc<string>("remoteB"); // sc-remote.2 — remote, pending
+          await ctx.run<string>("leafA"); // sc-remote:1
+          return ctx.rpc<string>("remoteB"); // sc-remote:2 — remote, pending
         })();
         await Promise.all([timer, chained]);
       };
@@ -189,7 +189,7 @@ describe("async engine structured concurrency", () => {
       // todo was lost (self-healing on resume, but a missed callback).
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect([...status.awaited].sort()).toEqual(["sc-remote.0", "sc-remote.2"]);
+      expect([...status.awaited].sort()).toEqual(["sc-remote:0", "sc-remote:2"]);
     } finally {
       await network.stop();
     }
@@ -201,13 +201,13 @@ describe("async engine structured concurrency", () => {
       const leafA = async (_i: Info) => "a";
       const leafB = async (_i: Info) => "b";
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-hops.0
+        const timer = ctx.sleep(60_000); // sc-hops:0
         const chained = (async () => {
-          await ctx.run<string>("leafA"); // sc-hops.1
+          await ctx.run<string>("leafA"); // sc-hops:1
           await null; // non-durable microtask hops between durable ops
           await null;
           await null;
-          return ctx.run<string>("leafB"); // sc-hops.2
+          return ctx.run<string>("leafB"); // sc-hops:2
         })();
         await Promise.all([timer, chained]);
       };
@@ -216,9 +216,9 @@ describe("async engine structured concurrency", () => {
 
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-hops.0"]);
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops.2");
-      expect((await getPromise(network, "sc-hops.2"))?.state).toBe("resolved");
+      expect(status.awaited).toEqual(["sc-hops:0"]);
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops:2");
+      expect((await getPromise(network, "sc-hops:2"))?.state).toBe("resolved");
     } finally {
       await network.stop();
     }
@@ -238,7 +238,7 @@ describe("async engine structured concurrency", () => {
             leaked = e;
           }
         })();
-        await ctx.sleep(60_000); // sc-zombie.0 — the pass suspends here
+        await ctx.sleep(60_000); // sc-zombie:0 — the pass suspends here
       };
 
       const status = await runRoot(network, { "sc-zombie": wf, leafA }, "sc-zombie");
@@ -247,7 +247,7 @@ describe("async engine structured concurrency", () => {
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
       // The panicked op never reached the server: no child promise was created.
-      expect(await getPromise(network, "sc-zombie.1")).toBeUndefined();
+      expect(await getPromise(network, "sc-zombie:1")).toBeUndefined();
     } finally {
       await network.stop();
     }
@@ -276,7 +276,7 @@ describe("async engine structured concurrency", () => {
 
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
-      expect(await getPromise(network, "sc-done.0")).toBeUndefined();
+      expect(await getPromise(network, "sc-done:0")).toBeUndefined();
     } finally {
       await network.stop();
     }

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -191,7 +191,7 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
@@ -211,14 +211,14 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:0", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
@@ -274,7 +274,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     // Second execution: everything resolved → done
     r = await exec("foo.1", foo, [], effects);
@@ -319,7 +319,7 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:0", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
@@ -342,14 +342,14 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
-    await completePromise(effects, `${id}.0`, { kind: "value", value: 42 });
+    await completePromise(effects, `${id}:0`, { kind: "value", value: 42 });
     r = await exec(id, foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, util.detachedId(id, `${id}.1`), { kind: "value", value: 42 });
+    await completePromise(effects, util.detachedId(id, `${id}:1`), { kind: "value", value: 42 });
     r = await exec(id, foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
@@ -359,10 +359,10 @@ describe("Coroutine", () => {
     // A detached workflow runs as its own root: resonate:origin is reset to its
     // own id (a fresh lineage). Recursive detached ids stay bounded NOT via
     // origin but via resonate:prefix, propagated unchanged across re-roots. Were
-    // the id minted off the (grown) origin, each level would add a `.d${hash}`
+    // the id minted off the (grown) origin, each level would add a `:d${hash}`
     // segment without bound; rooting it on the pinned prefix keeps it at
-    // `${prefix}.d${hash}` -- one segment past the prefix, at every depth.
-    const grownId = "top.deadbeefdeadbe"; // a workflow already several detached levels deep
+    // `${prefix}:d${hash}` -- one segment past the prefix, at every depth.
+    const grownId = "top:deadbeefdeadbe"; // a workflow already several detached levels deep
     const ctx = new InnerContext({
       id: grownId,
       oId: grownId, // detached re-roots origin to its own (grown) id
@@ -381,9 +381,9 @@ describe("Coroutine", () => {
 
     // The detached id is rooted at the pinned PREFIX "top", exactly one segment
     // past it -- NOT the grown id (which would add a segment per level).
-    expect(rfi.id).toBe(util.detachedId("top", `${grownId}.0`));
-    expect(rfi.id.startsWith("top.d")).toBe(true);
-    expect(rfi.id.split(".")).toHaveLength(2);
+    expect(rfi.id).toBe(util.detachedId("top", `${grownId}:0`));
+    expect(rfi.id.startsWith("top:d")).toBe(true);
+    expect(rfi.id.split(":")).toHaveLength(2);
 
     // The prefix carries forward unchanged, bounding the next level; the child's
     // lineage origin is its OWN id (a fresh lineage root).
@@ -396,10 +396,10 @@ describe("Coroutine", () => {
     // re-rooting each child exactly as production does -- a detached promise
     // executes as its own root with oId = its resonate:origin tag (its own id)
     // and prId = its resonate:prefix tag (computation.ts). The id is
-    // `${prefix}.d${cyrb53(seqid).padStart(14)}`: the hash flattens the
+    // `${prefix}:d${cyrb53(seqid).padStart(14)}`: the hash flattens the
     // (ever-growing) seqid to a constant 14 chars, and the prefix tag keeps the
     // prefix pinned to the top, so it never grows. Net: every detached id at
-    // every depth is exactly `${top}.d${14hex}` -- bounded regardless of depth.
+    // every depth is exactly `${top}:d${14hex}` -- bounded regardless of depth.
     const makeCtx = (id: string, oId: string, prId: string) =>
       new InnerContext({
         id,
@@ -445,9 +445,9 @@ describe("Coroutine", () => {
       frontier = next;
     }
 
-    // Bounded: a single length across all depths, exactly `${top}.d${14hex}`.
+    // Bounded: a single length across all depths, exactly `${top}:d${14hex}`.
     expect(lengths.size).toBe(1);
-    expect([...lengths][0]).toBe(TOP.length + ".d".length + 14);
+    expect([...lengths][0]).toBe(TOP.length + ":d".length + 14);
     // ...and no collisions: every node in the tree got a distinct id.
     expect(ids.size).toBe((FANOUT ** (DEPTH + 1) - FANOUT) / (FANOUT - 1));
   });
@@ -499,7 +499,7 @@ describe("Coroutine", () => {
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     r = await exec("foo.1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 84 } });
@@ -632,7 +632,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise that the child was waiting on
-    await completePromise(effects, "foo.1.0.0", { kind: "value", value: 21 });
+    await completePromise(effects, "foo.1:0.0", { kind: "value", value: 21 });
 
     // Second execution: child completes → parent completes
     r = await exec("foo.1", parent, [], effects);
@@ -658,7 +658,7 @@ describe("Coroutine", () => {
     expect(r.type).toBe("suspended");
 
     // Settle remote
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     // Re-execution: local promise already settled (fast-forward), completes
     r = await exec("foo.1", foo, [], effects);
@@ -698,8 +698,8 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote.length).toBeGreaterThanOrEqual(2);
 
     // Settle both remote promises
-    await completePromise(effects, "p.1.0", { kind: "value", value: 5 });
-    await completePromise(effects, "p.1.1.0", { kind: "value", value: 3 });
+    await completePromise(effects, "p.1:0", { kind: "value", value: 5 });
+    await completePromise(effects, "p.1:1.0", { kind: "value", value: 3 });
 
     // Second execution: everything settled → done
     r = await exec("p.1", parent, [], effects);
@@ -730,7 +730,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1); // only remoteParent
 
     // Settle the remote
-    await completePromise(effects, "p.1.0", { kind: "value", value: 8 });
+    await completePromise(effects, "p.1:0", { kind: "value", value: 8 });
 
     // Second execution: bar's durable promise was settled on first run → replay fast-path
     r = await exec("p.1", parent, [], effects);

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -50,7 +50,7 @@ describe("Decorator", () => {
 
     expect(r).toMatchObject({
       type: "internal.async.l",
-      id: "foo.0",
+      id: "foo:0",
     });
   });
 
@@ -177,14 +177,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     }); // pending promise → generator gets Future(pending), advances to second LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -231,7 +231,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -243,14 +243,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.1",
+      id: "foo:1",
     }); // B -> pending promise → generator gets Future(pending), advances to C -> LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -298,7 +298,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -309,7 +309,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 20 },
@@ -320,7 +320,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -507,10 +507,10 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     // Generator advances to yield* f (Future iterator: yield this)
-    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo.0" } });
+    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo:0" } });
 
     // Coroutine resolves inline and feeds a literal back
     r = d.next({
@@ -565,7 +565,7 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending" } });
 

--- a/tests/equivalence/workloads.ts
+++ b/tests/equivalence/workloads.ts
@@ -205,6 +205,6 @@ export const humanInTheLoop: MatchedWorkload = {
   gen: { dpc: dpcGen },
   async: { dpc: dpcAsync },
   drive: async (api) => {
-    await api.resolvePromise("dpc.0", "signal");
+    await api.resolvePromise("dpc:0", "signal");
   },
 };

--- a/tests/network/nats.test.ts
+++ b/tests/network/nats.test.ts
@@ -196,7 +196,7 @@ describe("NatsNetwork.send()", () => {
     await net.init();
 
     // origin is the lineage root: substring before the first dot of the id.
-    await net.send(promiseGetReq("foo.bar.baz", "c1"));
+    await net.send(promiseGetReq("foo:bar.baz", "c1"));
 
     const token = Buffer.from("foo", "utf8").toString("base64url");
     const reqPublish = fake.published.find((p) => p.subject.startsWith("resonate.requests."));
@@ -230,7 +230,7 @@ describe("NatsNetwork.send()", () => {
         action: {
           kind: "promise.create",
           head: { corrId: "c1", version: VERSION },
-          data: { id: "root.child.1", timeoutAt: 1, param: {}, tags: {} },
+          data: { id: "root:child.1", timeoutAt: 1, param: {}, tags: {} },
         },
       },
     };

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -85,15 +85,15 @@ describe("Resonate usage tests", () => {
     function* bar(ctx: Context): Generator {
       // origin: foo.1
       // parent: foo.1
-      // branch: foo.1.0
+      // branch: foo.1:0
       const v = yield ctx.rpc(baz);
       return v;
     }
 
     async function baz(ctx: Context): Promise<string> {
       // origin: foo.1
-      // parent: foo.1.0
-      // branch: foo.1.0.0
+      // parent: foo.1:0
+      // branch: foo.1:0.0
       return "hello";
     }
 
@@ -110,19 +110,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
+      "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+      "resonate:branch": "foo.1:0.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -156,19 +156,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
-      "resonate:branch": "foo.0",
+      "resonate:branch": "foo:0",
       "resonate:parent": "foo",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
-      "resonate:branch": "foo.0.0",
-      "resonate:parent": "foo.0",
+      "resonate:branch": "foo:0.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -200,18 +200,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
     });
   });
@@ -241,18 +241,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
       "resonate:branch": "foo",
-      "resonate:parent": "foo.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "local",
     });
   });
@@ -454,14 +454,14 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
     await resonate.stop();
   });
@@ -479,7 +479,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await resonate.rpc(`f${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`f${i}`);
-      const p2 = await resonate.promises.get(`f${i}.0`);
+      const p2 = await resonate.promises.get(`f${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -497,7 +497,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await resonate.rpc(`g${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`g${i}`);
-      const p2 = await resonate.promises.get(`g${i}.0`);
+      const p2 = await resonate.promises.get(`g${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -514,14 +514,14 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function");
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "f",
@@ -538,19 +538,19 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -563,19 +563,19 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe(`${ctx.id}.0`);
+      expect(fu.id).toBe(`${ctx.id}:0`);
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure myId promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -591,24 +591,24 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
@@ -624,12 +624,12 @@ describe("Resonate usage tests", () => {
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -657,7 +657,7 @@ describe("Resonate usage tests", () => {
     const v = await f.run("f");
     expect(v).toBe("myValue");
 
-    const durable = await resonate.promises.get(util.detachedId("f", "f.0"));
+    const durable = await resonate.promises.get(util.detachedId("f", "f:0"));
     expect(durable).toMatchObject({ state: "pending" });
 
     await resonate.stop();
@@ -764,11 +764,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -790,11 +790,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -816,11 +816,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -1254,10 +1254,10 @@ describe("Context usage tests", () => {
       expect(ctxRetryPolicy).toEqual(retryPolicy);
 
       if (f === "rfi" || f === "rfc") {
-        const p = await resonate.promises.get(`f${i}.0`);
+        const p = await resonate.promises.get(`f${i}:0`);
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       } else if (f === "detached") {
-        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}.0`));
+        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}:0`));
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       }
     }

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -452,7 +452,7 @@ describe("Trace", () => {
       const { computation, effects } = await buildComputation(registry);
 
       // Pre-settle the child promise
-      await presettle(effects, "foo.1.0", 42);
+      await presettle(effects, "foo.1:0", 42);
 
       const rootPromise = createRootPromise("foo.1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -181,39 +181,39 @@ describe("base64 encoder", () => {
 
 describe("detachedId", () => {
   test("returns prefix dot-d plus cyrb53 hex of seqid", () => {
-    const result = detachedId("root", "root.0");
-    expect(result).toBe(detachedId("root", "root.0"));
-    expect(result.startsWith("root.d")).toBe(true);
+    const result = detachedId("root", "root:0");
+    expect(result).toBe(detachedId("root", "root:0"));
+    expect(result.startsWith("root:d")).toBe(true);
   });
 
   test("segment after the prefix is a `d` marker followed by hex", () => {
-    const result = detachedId("origin", "origin.3");
-    const segment = result.split(".").slice(1).join(".");
+    const result = detachedId("origin", "origin:3");
+    const segment = result.split(":").slice(1).join(":");
     expect(segment[0]).toBe("d");
     expect(segment.slice(1)).toMatch(/^[0-9a-f]+$/);
   });
 
   test("is deterministic — same inputs produce same output", () => {
-    expect(detachedId("a", "a.0")).toBe(detachedId("a", "a.0"));
+    expect(detachedId("a", "a:0")).toBe(detachedId("a", "a:0"));
   });
 
   test("different seqids produce different ids", () => {
-    expect(detachedId("root", "root.0")).not.toBe(detachedId("root", "root.1"));
+    expect(detachedId("root", "root:0")).not.toBe(detachedId("root", "root:1"));
   });
 
   test("different prefixes produce different ids", () => {
-    expect(detachedId("root.0", "root.0.0")).not.toBe(detachedId("root.1", "root.0.0"));
+    expect(detachedId("root:0", "root:0.0")).not.toBe(detachedId("root:1", "root:0.0"));
   });
 
   test("prefix is preserved before the `.d` segment", () => {
     const prefix = "my-workflow-abc123";
-    const result = detachedId(prefix, "my-workflow-abc123.5");
-    expect(result.startsWith(`${prefix}.d`)).toBe(true);
+    const result = detachedId(prefix, "my-workflow-abc123:5");
+    expect(result.startsWith(`${prefix}:d`)).toBe(true);
   });
 
   test("works with empty strings", () => {
     const result = detachedId("", "");
-    expect(result.startsWith(".d")).toBe(true);
+    expect(result.startsWith(":d")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Adopts the `<promiseId>:<lineage>` id convention. A single `:` separates the
promiseId (the lineage origin) from the lineage; **within the lineage the
separator stays `.`**. So:

- `foo.1`   -> `foo:1`     (promiseId `foo`, lineage `1`)
- `foo.1.1` -> `foo:1.1`   (promiseId `foo`, lineage `1.1`)

What changed:
- Id generation: the first lineage segment minted off a bare promiseId
  (`id == origin`) uses `:`; deeper segments use `.`. Detached ids mint
  `{prefix}:d{hash}` (their first lineage segment off the fixed prefix).
- Origin derivation splits on the first `:` (NATS routing, where applicable).
- Updated fixtures/tests.

The schedule promise-id template keeps `.` (`{{.id}}.{{.timestamp}}`): a
scheduled promise is a self-rooted promiseId, not a lineage. The app id prefix
(`RESONATE_PREFIX`, `:`-joined) is unchanged. Companion server-side changes
handle the matching validation and origin rules.
