### PR TITLE
feat: new promise id format (':' lineage separator, drop id prefix)

### DIFF
--- a/examples/async/human-in-the-loop.ts
+++ b/examples/async/human-in-the-loop.ts
@@ -67,7 +67,7 @@ async function cancelOrder(_info: Info, orderId: string, note: string): Promise<
 // -- Orchestrator ---------------------------------------------------------
 
 async function fulfillOrder(ctx: Context, orderId: string, amount: number): Promise<string> {
-  // Open the human-decision promise first. Its `.id` (`{workflowId}.0`) is
+  // Open the human-decision promise first. Its `.id` (`{workflowId}:0`) is
   // available synchronously -- the address to resolve.
   const approval = ctx.promise<Decision>();
   await ctx.run(notifyReviewer, orderId, amount, approval.id);

--- a/examples/async/structured-concurrency.ts
+++ b/examples/async/structured-concurrency.ts
@@ -13,8 +13,8 @@
 // spawned is still in flight. Before foo's promise resolves, the runtime joins
 // both children.
 //
-// We prove it durably. Children get deterministic ids `{foo_id}.0` and
-// `{foo_id}.1`. After foo returns 5 we attach to those two promises by id and
+// We prove it durably. Children get deterministic ids `{foo_id}:0` and
+// `{foo_id}:1`. After foo returns 5 we attach to those two promises by id and
 // assert each resolved -- evidence the never-awaited work was awaited *by the
 // runtime* on our behalf.
 //
@@ -50,12 +50,12 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order as `{parent}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/examples/generator/human-in-the-loop.ts
+++ b/examples/generator/human-in-the-loop.ts
@@ -71,7 +71,7 @@ async function cancelOrder(_ctx: Context, orderId: string, note: string): Promis
 
 function* fulfillOrder(ctx: Context, orderId: string, amount: number): Generator<any, string, any> {
   // Open the human-decision promise first so its id is deterministic
-  // (`{workflowId}.0`). The Future's `.id` is the address to resolve.
+  // (`{workflowId}:0`). The Future's `.id` is the address to resolve.
   const approval = yield* ctx.promise<Decision>();
   const approvalId = approval.id;
 

--- a/examples/generator/structured-concurrency.ts
+++ b/examples/generator/structured-concurrency.ts
@@ -12,7 +12,7 @@
 // flight. Before foo's promise resolves, the runtime joins both children.
 //
 // We prove it durably. `ctx.beginRun` children get deterministic ids
-// `{foo_id}.0` and `{foo_id}.1`. After foo returns 5 we attach to those two
+// `{foo_id}:0` and `{foo_id}:1`. After foo returns 5 we attach to those two
 // promises by id and assert each resolved -- evidence the never-awaited work
 // was awaited *by the runtime* on our behalf.
 //
@@ -48,12 +48,12 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order as `{parent}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/packages/aws/src/index.ts
+++ b/packages/aws/src/index.ts
@@ -28,7 +28,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string;
   private dependencies: Map<string, any>;
@@ -54,8 +53,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     pid = undefined,
@@ -66,7 +63,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -76,11 +72,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    const resolvedPrefix = prefix ?? process.env.RESONATE_PREFIX;
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid ?? crypto.randomUUID().replace(/-/g, "");
@@ -204,7 +197,6 @@ export class Resonate {
               if (isUrl(target)) return target;
               return functionUrl;
             },
-            idPrefix: this.idPrefix,
           }),
           logger: this.logger,
         });

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -28,7 +28,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string | undefined;
   private dependencies: Map<string, any>;
@@ -55,7 +54,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs.
    */
   constructor({
     pid = undefined,
@@ -66,7 +64,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -76,10 +73,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    this.idPrefix = prefix ? `${prefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid;
@@ -188,7 +183,6 @@ export class Resonate {
                 if (isUrl(target)) return target;
                 return functionUrl;
               },
-              idPrefix: this.idPrefix,
             }),
             logger: this.logger,
           });

--- a/packages/gcp/src/index.ts
+++ b/packages/gcp/src/index.ts
@@ -31,7 +31,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string;
   private dependencies: Map<string, any>;
@@ -61,8 +60,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     pid = undefined,
@@ -73,7 +70,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -83,11 +79,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    const resolvedPrefix = prefix ?? process.env.RESONATE_PREFIX;
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid ?? crypto.randomUUID().replace(/-/g, "");
@@ -196,7 +189,6 @@ export class Resonate {
               if (isUrl(target)) return target;
               return `${proto}://${host}${req.originalUrl || ""}`;
             },
-            idPrefix: this.idPrefix,
           }),
           logger: this.logger,
         });

--- a/sim/src/worker.ts
+++ b/sim/src/worker.ts
@@ -211,7 +211,7 @@ export class WorkerProcess extends Process {
       registry,
       heartbeat: new NoopHeartbeat(),
       dependencies: new Map(),
-      optsBuilder: new OptionsBuilder({ match: (target: string) => `sim://any@${target}`, idPrefix: "" }),
+      optsBuilder: new OptionsBuilder({ match: (target: string) => `sim://any@${target}` }),
       logger,
     });
     this.network.recv((msg) => {

--- a/src/async/context.ts
+++ b/src/async/context.ts
@@ -31,10 +31,6 @@ export interface Info {
   readonly id: string;
   readonly parentId: string;
   readonly originId: string;
-  /** The id-generation prefix (resonate:prefix). Set once at the top and
-   * propagated down unchanged — through every child AND across detached
-   * re-roots — so recursive detached ids stay bounded. */
-  readonly prefixId: string;
   readonly branchId: string;
   readonly timeoutAt: number;
   readonly attempt: number;
@@ -166,7 +162,6 @@ export class DurablePromise<T> implements Promise<T> {
 interface AsyncContextConfig {
   id: string;
   oId?: string;
-  prId?: string;
   bId?: string;
   pId?: string;
   func: string;
@@ -182,7 +177,6 @@ interface AsyncContextConfig {
 export class AsyncContext implements Context {
   readonly id: string;
   readonly originId: string;
-  readonly prefixId: string;
   readonly branchId: string;
   readonly parentId: string;
   readonly func: string;
@@ -219,7 +213,6 @@ export class AsyncContext implements Context {
   constructor(cfg: AsyncContextConfig, effects: Effects, trace: TraceCollector) {
     this.id = cfg.id;
     this.originId = cfg.oId ?? cfg.id;
-    this.prefixId = cfg.prId ?? cfg.id;
     this.branchId = cfg.bId ?? cfg.id;
     this.parentId = cfg.pId ?? cfg.id;
     this.func = cfg.func;
@@ -278,7 +271,6 @@ export class AsyncContext implements Context {
       {
         id: cfg.id,
         oId: this.originId,
-        prId: this.prefixId,
         bId: this.branchId,
         pId: this.id,
         func: cfg.func,
@@ -471,7 +463,7 @@ export class AsyncContext implements Context {
     // Detached ids are minted off the fixed id-generation prefix (NOT the grown
     // id or the diverging origin), so recursive detached stays bounded at one
     // segment past the prefix. Mirrors the generator engine (src/context.ts).
-    const id = idChanged ? (opts.id as string) : util.detachedId(this.prefixId, this.seqid());
+    const id = idChanged ? (opts.id as string) : util.detachedId(this.originId, this.seqid());
     this.seq++;
 
     const func = registered ? registered.name : (funcOrName as string);
@@ -658,9 +650,6 @@ export class AsyncContext implements Context {
         "resonate:branch": this.branchId,
         "resonate:parent": this.id,
         "resonate:origin": breaksLineage ? id : this.originId,
-        // Prefix is set at the top and propagates down unchanged forever,
-        // independent of origin (which detached/explicit-id may break).
-        "resonate:prefix": this.prefixId,
         ...opts.tags,
       },
     });
@@ -687,9 +676,6 @@ export class AsyncContext implements Context {
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": breaksLineage ? id : this.originId,
-        // Prefix is set at the top and propagates down unchanged forever,
-        // independent of origin (which detached/explicit-id may break).
-        "resonate:prefix": this.prefixId,
         ...opts.tags,
       },
     });
@@ -708,9 +694,6 @@ export class AsyncContext implements Context {
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": id,
-        // Prefix carries forward unchanged across the detached re-root (origin
-        // breaks, prefix does not) — this is what keeps recursive ids bounded.
-        "resonate:prefix": this.prefixId,
         ...opts.tags,
       },
     });
@@ -737,8 +720,6 @@ export class AsyncContext implements Context {
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": this.originId,
-        // Prefix is set at the top and propagates down unchanged forever.
-        "resonate:prefix": this.prefixId,
         ...tags,
       },
     });
@@ -754,8 +735,6 @@ export class AsyncContext implements Context {
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": this.originId,
-        // Prefix is set at the top and propagates down unchanged forever.
-        "resonate:prefix": this.prefixId,
         "resonate:timer": "true",
       },
     });

--- a/src/async/context.ts
+++ b/src/async/context.ts
@@ -88,7 +88,7 @@ export interface Context extends Info {
    * Creates a latent durable promise (DPC) with no associated function, intended
    * to be resolved out of band (human-in-the-loop / external signal) via
    * `resonate.promises.resolve(id)`. Awaiting it suspends the parent until the
-   * promise is settled externally. The id is `${ctx.id}.${seq}`.
+   * promise is settled externally. The id is `${ctx.id}:${seq}` (or `.${seq}` when nested).
    */
   promise<T>(opts?: { timeout?: number; data?: any; tags?: { [key: string]: string } }): DurablePromise<T>;
 
@@ -762,7 +762,12 @@ export class AsyncContext implements Context {
   }
 
   private seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // `<promiseId>:<lineage>`: a single `:` separates the promiseId (lineage
+    // origin) from the lineage, and `.` separates lineage segments. The first
+    // segment minted off a bare promiseId (id === originId) uses `:`
+    // (`root` -> `root:1`); deeper segments use `.` (`root:1` -> `root:1.1`).
+    const sep = this.id === this.originId ? ":" : ".";
+    return `${this.id}${sep}${this.seq}`;
   }
 }
 

--- a/src/async/core.ts
+++ b/src/async/core.ts
@@ -183,11 +183,6 @@ export class Core {
           {
             id: rootPromise.id,
             oId: rootPromise.tags["resonate:origin"] ?? rootPromise.id,
-            // The id-generation prefix, propagated unchanged across re-roots (a
-            // detached child resets origin to its own id but carries prefix
-            // forward), so recursive detached ids stay bounded. Falls back to
-            // the id like oId.
-            prId: rootPromise.tags["resonate:prefix"] ?? rootPromise.id,
             func: registered.func.name,
             clock: this.clock,
             registry: this.registry,

--- a/src/async/resonate.ts
+++ b/src/async/resonate.ts
@@ -60,7 +60,6 @@ export class Resonate {
   private clock: WallClock;
   private pid: string;
   private ttl: number;
-  private idPrefix: string;
 
   private core: Core;
   private codec: Codec;
@@ -91,7 +90,6 @@ export class Resonate {
     logger = undefined,
     encryptor = undefined,
     network = undefined,
-    prefix = undefined,
   }: {
     url?: string;
     group?: string;
@@ -104,14 +102,10 @@ export class Resonate {
     logger?: Logger;
     encryptor?: Encryptor;
     network?: Network;
-    prefix?: string;
   } = {}) {
     this.clock = new WallClock();
     this.ttl = ttl;
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-
-    const resolvedPrefix = prefix ?? getEnv("RESONATE_PREFIX");
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
 
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
@@ -155,7 +149,7 @@ export class Resonate {
 
     this.registry = new Registry();
     this.dependencies = new Map();
-    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network), idPrefix: this.idPrefix });
+    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network) });
 
     this.core = new Core({
       pid: this.pid,
@@ -254,7 +248,6 @@ export class Resonate {
       );
     }
 
-    id = `${this.idPrefix}${id}`;
     util.assert(registered.version > 0, "function version must be greater than zero");
 
     const { promise, task } = await this.taskCreate({
@@ -276,9 +269,6 @@ export class Resonate {
             tags: {
               ...opts.tags,
               "resonate:origin": id,
-              // A genuine top-level root is its own lineage origin AND its own
-              // id-generation prefix; the prefix then propagates down unchanged.
-              "resonate:prefix": id,
               "resonate:branch": id,
               "resonate:parent": id,
               "resonate:scope": "global",
@@ -318,7 +308,6 @@ export class Resonate {
       throw exceptions.REGISTRY_FUNCTION_NOT_REGISTERED(funcOrName.name, opts.version);
     }
 
-    id = `${this.idPrefix}${id}`;
     const func = registered ? registered.name : (funcOrName as string);
     const version = registered ? registered.version : opts.version || 1;
 
@@ -332,9 +321,6 @@ export class Resonate {
         tags: {
           ...opts.tags,
           "resonate:origin": id,
-          // A genuine top-level root is its own lineage origin AND its own
-          // id-generation prefix; the prefix then propagates down unchanged.
-          "resonate:prefix": id,
           "resonate:branch": id,
           "resonate:parent": id,
           "resonate:scope": "global",
@@ -377,7 +363,7 @@ export class Resonate {
       version: registered ? registered.version : opts.version || 1,
     });
 
-    await this.schedules.create(name, cron, `${this.idPrefix}{{.id}}.{{.timestamp}}`, opts.timeout, {
+    await this.schedules.create(name, cron, "{{.id}}.{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,
       promiseData: data,
       promiseTags: { ...opts.tags, "resonate:target": opts.target },
@@ -390,7 +376,6 @@ export class Resonate {
 
   /** Returns a handle to an existing durable promise by id. */
   public async get<T = any>(id: string): Promise<ResonateHandle<T>> {
-    id = `${this.idPrefix}${id}`;
     const promise = await this.promiseGet({
       kind: "promise.get",
       head: { corrId: randomUUID(), version: util.VERSION },

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -117,10 +117,6 @@ export class Computation {
     const ctxConfig = {
       id: this.id,
       oId: rootPromise.tags["resonate:origin"] ?? this.id,
-      // The id-generation prefix, propagated unchanged across re-roots (a
-      // detached child resets origin to its own id but carries prefix forward),
-      // so recursive detached ids stay bounded. Falls back to the id like oId.
-      prId: rootPromise.tags["resonate:prefix"] ?? this.id,
       func: registered.func.name,
       clock: this.clock,
       registry: this.registry,

--- a/src/context.ts
+++ b/src/context.ts
@@ -192,7 +192,6 @@ export class Future<T> implements Iterable<Future<T>> {
 export interface Context {
   readonly id: string;
   readonly originId: string;
-  readonly prefixId: string;
   readonly parentId: string;
   readonly branchId: string;
   readonly info: { readonly attempt: number; readonly timeout: number; readonly version: number };
@@ -273,7 +272,6 @@ export class InnerContext implements Context {
   readonly nonRetryableErrors: Array<new (...args: any[]) => Error>;
 
   readonly originId: string;
-  readonly prefixId: string;
   readonly branchId: string;
   readonly parentId: string;
   readonly clock: Clock;
@@ -290,7 +288,6 @@ export class InnerContext implements Context {
   constructor({
     id,
     oId = id,
-    prId = id,
     bId = id,
     pId = id,
     func,
@@ -305,7 +302,6 @@ export class InnerContext implements Context {
   }: {
     id: string;
     oId?: string;
-    prId?: string;
     bId?: string;
     pId?: string;
     func: string;
@@ -320,13 +316,6 @@ export class InnerContext implements Context {
   }) {
     this.id = id;
     this.originId = oId;
-    // The id-generation prefix (resonate:prefix). Set once at the top
-    // (resonate.run/rpc) and propagated down unchanged forever -- through every
-    // child AND across detached re-roots -- never tracking the (diverging)
-    // lineage origin. Bounds recursive detached ids: each level mints
-    // `${prefixId}:d${hash}` off this fixed prefix. Mirrors the Python SDK's
-    // `Context.prefix_id`.
-    this.prefixId = prId;
     this.branchId = bId;
     this.parentId = pId;
     this.func = func;
@@ -362,7 +351,6 @@ export class InnerContext implements Context {
     return new InnerContext({
       id,
       oId: this.originId,
-      prId: this.prefixId,
       bId: this.branchId,
       pId: this.id,
       func,
@@ -573,7 +561,7 @@ export class InnerContext implements Context {
 
     const idChanged = opts.id !== undefined;
 
-    const id = idChanged ? opts.id : util.detachedId(this.prefixId, this.seqid());
+    const id = idChanged ? opts.id : util.detachedId(this.originId, this.seqid());
     this.seq++;
 
     const func = registered ? registered.name : (funcOrName as string);
@@ -592,13 +580,9 @@ export class InnerContext implements Context {
       version,
       // detached ALWAYS breaks the origin lineage (breaksLineage: true): it is
       // fire-and-forget and runs as its own root, so resonate:origin must equal
-      // its own id (origin == id == branch), starting a fresh lineage. Recursive
-      // detached ids stay bounded NOT via origin but via resonate:prefix, which
-      // is propagated down unchanged (set in remoteCreateReq = this.prefixId) and
-      // is what `util.detachedId(this.prefixId, ...)` roots the id on. So each
-      // level mints `${prefix}:d${hash}` off the same fixed prefix instead of
-      // off its own grown id. Mirrors the Python SDK (detached origin = its id,
-      // prefix carried forward).
+      // its own id (origin == id == branch), starting a fresh lineage. Each
+      // level mints `${origin}:d${hash}` off the same origin instead of
+      // off its own grown id. Mirrors the Python SDK (detached origin = its id).
       this.remoteCreateReq({ id, data, opts, maxTimeout: Number.MAX_SAFE_INTEGER, breaksLineage: true }),
       "detached",
     );
@@ -683,9 +667,6 @@ export class InnerContext implements Context {
           "resonate:branch": this.branchId,
           "resonate:parent": this.id,
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...opts.tags,
         },
       },
@@ -720,9 +701,6 @@ export class InnerContext implements Context {
           "resonate:branch": id,
           "resonate:parent": this.id,
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...opts.tags,
         },
         param: { headers: {}, data },
@@ -758,9 +736,6 @@ export class InnerContext implements Context {
           "resonate:branch": id,
           "resonate:parent": this.id,
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...tags,
         },
       },
@@ -773,8 +748,6 @@ export class InnerContext implements Context {
       "resonate:branch": id,
       "resonate:parent": this.id,
       "resonate:origin": this.originId,
-      // Prefix is set at the top and propagates down unchanged forever.
-      "resonate:prefix": this.prefixId,
       "resonate:timer": "true",
     };
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -324,7 +324,7 @@ export class InnerContext implements Context {
     // (resonate.run/rpc) and propagated down unchanged forever -- through every
     // child AND across detached re-roots -- never tracking the (diverging)
     // lineage origin. Bounds recursive detached ids: each level mints
-    // `${prefixId}.d${hash}` off this fixed prefix. Mirrors the Python SDK's
+    // `${prefixId}:d${hash}` off this fixed prefix. Mirrors the Python SDK's
     // `Context.prefix_id`.
     this.prefixId = prId;
     this.branchId = bId;
@@ -596,7 +596,7 @@ export class InnerContext implements Context {
       // detached ids stay bounded NOT via origin but via resonate:prefix, which
       // is propagated down unchanged (set in remoteCreateReq = this.prefixId) and
       // is what `util.detachedId(this.prefixId, ...)` roots the id on. So each
-      // level mints `${prefix}.d${hash}` off the same fixed prefix instead of
+      // level mints `${prefix}:d${hash}` off the same fixed prefix instead of
       // off its own grown id. Mirrors the Python SDK (detached origin = its id,
       // prefix carried forward).
       this.remoteCreateReq({ id, data, opts, maxTimeout: Number.MAX_SAFE_INTEGER, breaksLineage: true }),
@@ -794,6 +794,11 @@ export class InnerContext implements Context {
   }
 
   seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // `<promiseId>:<lineage>`: a single `:` separates the promiseId (lineage
+    // origin) from the lineage, and `.` separates lineage segments. The first
+    // segment minted off a bare promiseId (id === originId) uses `:`; deeper
+    // segments use `.` (`root:1` -> `root:1.1`).
+    const sep = this.id === this.originId ? ":" : ".";
+    return `${this.id}${sep}${this.seq}`;
   }
 }

--- a/src/network/nats.ts
+++ b/src/network/nats.ts
@@ -32,10 +32,10 @@ const REPLY_HEADER = "Resonate-Reply-To";
 // ROUTING HELPERS
 // =============================================================================
 
-// Return the lineage origin: the substring before the first `.`.
+// Return the lineage origin (promiseId): the substring before the first `:`.
 function idToOrigin(id: string): string {
-  const dot = id.indexOf(".");
-  return dot === -1 ? id : id.slice(0, dot);
+  const sep = id.indexOf(":");
+  return sep === -1 ? id : id.slice(0, sep);
 }
 
 // Derive the routing origin from a request, mirroring the server's client.

--- a/src/options.ts
+++ b/src/options.ts
@@ -5,10 +5,8 @@ export const RESONATE_OPTIONS: unique symbol = Symbol("ResonateOptions");
 
 export class OptionsBuilder {
   private match: (target: string) => string;
-  private idPrefix: string;
-  constructor({ match, idPrefix }: { match: (target: string) => string; idPrefix: string }) {
+  constructor({ match }: { match: (target: string) => string }) {
     this.match = (target: string) => (util.isUrl(target) ? target : match(target));
-    this.idPrefix = idPrefix;
   }
 
   build({
@@ -28,7 +26,6 @@ export class OptionsBuilder {
     version?: number;
     nonRetryableErrors?: Array<new (...args: any[]) => Error>;
   } = {}): Options {
-    id = id ? `${this.idPrefix}${id}` : id;
     return new Options({ id, retryPolicy, tags, target: this.match(target), timeout, version, nonRetryableErrors });
   }
 }

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -57,7 +57,6 @@ export class Resonate {
 
   private pid: string;
   private ttl: number;
-  private idPrefix;
 
   private core: Core;
   private codec: Codec;
@@ -94,8 +93,6 @@ export class Resonate {
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
    * @param options.network - Custom network implementation. Defaults to `undefined`.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     url = undefined,
@@ -109,7 +106,6 @@ export class Resonate {
     logger = undefined,
     encryptor = undefined,
     network = undefined,
-    prefix = undefined,
   }: {
     url?: string;
     group?: string;
@@ -122,14 +118,10 @@ export class Resonate {
     logger?: Logger;
     encryptor?: Encryptor;
     network?: Network;
-    prefix?: string;
   } = {}) {
     this.clock = new WallClock();
     this.ttl = ttl;
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-
-    const resolvedPrefix = prefix ?? getEnv("RESONATE_PREFIX");
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
 
     // Resolve logger: explicit logger > ConsoleLogger with resolved level
     // logLevel takes precedence over verbose; verbose: true -> "debug"
@@ -182,7 +174,7 @@ export class Resonate {
     this.registry = new Registry();
     this.dependencies = new Map();
 
-    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network), idPrefix: this.idPrefix });
+    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network) });
 
     this.core = new Core({
       pid: this.pid,
@@ -310,8 +302,6 @@ export class Resonate {
       );
     }
 
-    id = `${this.idPrefix}${id}`;
-
     util.assert(registered.version > 0, "function version must be greater than zero");
     const { promise, task } = await this.taskCreate({
       kind: "task.create",
@@ -337,9 +327,6 @@ export class Resonate {
             tags: {
               ...opts.tags,
               "resonate:origin": id,
-              // A genuine top-level root is its own lineage origin AND its own
-              // id-generation prefix; the prefix then propagates down unchanged.
-              "resonate:prefix": id,
               "resonate:branch": id,
               "resonate:parent": id,
               "resonate:scope": "global",
@@ -387,8 +374,6 @@ export class Resonate {
       throw exceptions.REGISTRY_FUNCTION_NOT_REGISTERED(funcOrName.name, opts.version);
     }
 
-    id = `${this.idPrefix}${id}`;
-
     const func = registered ? registered.name : (funcOrName as string);
     const version = registered ? registered.version : opts.version || 1;
     const promise = await this.promiseCreate({
@@ -409,9 +394,6 @@ export class Resonate {
         tags: {
           ...opts.tags,
           "resonate:origin": id,
-          // A genuine top-level root is its own lineage origin AND its own
-          // id-generation prefix; the prefix then propagates down unchanged.
-          "resonate:prefix": id,
           "resonate:branch": id,
           "resonate:parent": id,
           "resonate:scope": "global",
@@ -475,7 +457,7 @@ export class Resonate {
       version: registered ? registered.version : opts.version || 1,
     });
 
-    await this.schedules.create(name, cron, `${this.idPrefix}{{.id}}.{{.timestamp}}`, opts.timeout, {
+    await this.schedules.create(name, cron, "{{.id}}.{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,
       promiseData: data,
       promiseTags: { ...opts.tags, "resonate:target": opts.target },
@@ -487,7 +469,6 @@ export class Resonate {
   }
 
   public async get<T = any>(id: string): Promise<ResonateHandle<T>> {
-    id = `${this.idPrefix}${id}`;
     const promise = await this.promiseGet({
       kind: "promise.get",
       head: { corrId: randomUUID(), version: util.VERSION },

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,13 +112,12 @@ function cyrb53(input: string | Uint8Array, seed = 0): number {
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 }
 
-export function detachedId(prefix: string, seqid: string): string {
-  // `${prefix}:d${hash}` -- the `:` is the promiseId->lineage boundary and the
+export function detachedId(origin: string, seqid: string): string {
+  // `${origin}:d${hash}` -- the `:` is the promiseId->lineage boundary and the
   // `d` marks the segment as a detached child (vs an rfi child's numeric
-  // `:${seq}`). `prefix` is the id-generation prefix (resonate:prefix), set once
-  // at the top and propagated down unchanged, so recursive detached ids stay
-  // bounded at one segment past the prefix.
-  return `${prefix}:d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
+  // `:${seq}`). `origin` is the lineage origin, so recursive detached ids stay
+  // bounded at one segment past the origin.
+  return `${origin}:d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
 }
 
 export function getCallerInfo(): string {

--- a/src/util.ts
+++ b/src/util.ts
@@ -113,11 +113,12 @@ function cyrb53(input: string | Uint8Array, seed = 0): number {
 }
 
 export function detachedId(prefix: string, seqid: string): string {
-  // `${prefix}.d${hash}` -- the `d` marks the segment as a detached child (vs an
-  // rfi child's numeric `.${seq}`). `prefix` is the id-generation prefix
-  // (resonate:prefix), set once at the top and propagated down unchanged, so
-  // recursive detached ids stay bounded at one segment past the prefix.
-  return `${prefix}.d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
+  // `${prefix}:d${hash}` -- the `:` is the promiseId->lineage boundary and the
+  // `d` marks the segment as a detached child (vs an rfi child's numeric
+  // `:${seq}`). `prefix` is the id-generation prefix (resonate:prefix), set once
+  // at the top and propagated down unchanged, so recursive detached ids stay
+  // bounded at one segment past the prefix.
+  return `${prefix}:d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
 }
 
 export function getCallerInfo(): string {

--- a/tests/async/async-trace.test.ts
+++ b/tests/async/async-trace.test.ts
@@ -165,14 +165,14 @@ describe("async engine lifecycle trace", () => {
     // Root spawn is first.
     expect(t[0]).toEqual({ kind: "spawn", id: "main" });
 
-    // run main -> main.0
+    // run main -> main:0
     const run = t.find((e) => e.kind === "run");
-    expect(run).toEqual({ kind: "run", id: "main", callee: "main.0" });
+    expect(run).toEqual({ kind: "run", id: "main", callee: "main:0" });
 
     // Child spawns once and returns 7.
     expect(counts(t).spawn.filter((e) => e.id !== "main").length).toBe(1);
-    const childReturn = t.find((e) => e.kind === "return" && e.id === "main.0");
-    expect(childReturn).toEqual({ kind: "return", id: "main.0", state: "resolved", value: 7 });
+    const childReturn = t.find((e) => e.kind === "return" && e.id === "main:0");
+    expect(childReturn).toEqual({ kind: "return", id: "main:0", state: "resolved", value: 7 });
 
     // Root return is last.
     expect(t[t.length - 1]).toEqual({ kind: "return", id: "main", state: "resolved", value: 7 });
@@ -237,7 +237,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.state).toBe("rejected");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn.kind === "return" && rootReturn.state).toBe("rejected");
@@ -264,7 +264,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.value).toBe("caught:kaboom");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn).toMatchObject({ kind: "return", id: "main", state: "resolved" });
@@ -279,12 +279,12 @@ describe("async engine lifecycle trace", () => {
     const res = await runRoot(fns, "main");
 
     expect(res.kind).toBe("suspended");
-    if (res.kind === "suspended") expect(res.awaited).toEqual(["main.0"]);
+    if (res.kind === "suspended") expect(res.awaited).toEqual(["main:0"]);
     const t = res.trace;
 
     expect(t[0]).toEqual({ kind: "spawn", id: "main" });
-    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main.0" });
-    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main.0" });
+    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main:0" });
+    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main:0" });
     expect(t[t.length - 1]).toEqual({ kind: "suspend", id: "main" });
 
     expectLifecycleWellFormed(t);
@@ -353,9 +353,9 @@ describe("async engine lifecycle trace", () => {
       const core = newCore(registryOf(fns), network);
       const { task, promise, preload } = await seedRoot(network, "main", "main", []);
 
-      // Pre-settle the child (main.0) so the engine's create dedups against it.
+      // Pre-settle the child (main:0) so the engine's create dedups against it.
       const effects = util.buildEffects(network.send, codec, { id: task.id, version: task.version });
-      await presettle(effects, "main.0", 99);
+      await presettle(effects, "main:0", 99);
 
       const res = await core.executeUntilBlocked(task, promise, preload);
 
@@ -363,10 +363,10 @@ describe("async engine lifecycle trace", () => {
       if (res.kind === "done") expect(res.value).toBe(99); // deduped to the stored value
 
       const c = counts(res.trace);
-      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main.0" }]);
+      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main:0" }]);
       expect(c.dedup.length).toBe(1);
-      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main.0", state: "resolved" });
-      expect(c.spawn.filter((e) => e.id === "main.0").length).toBe(0); // deduped, never spawned
+      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main:0", state: "resolved" });
+      expect(c.spawn.filter((e) => e.id === "main:0").length).toBe(0); // deduped, never spawned
 
       expectLifecycleWellFormed(res.trace);
     } finally {

--- a/tests/async/async-trace.test.ts
+++ b/tests/async/async-trace.test.ts
@@ -52,7 +52,7 @@ function newCore(registry: Registry, network: LocalNetwork): Core {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (target: string) => target, idPrefix: "" }),
+    optsBuilder: new OptionsBuilder({ match: (target: string) => target }),
     logger: new ConsoleLogger("error"),
   });
 }

--- a/tests/async/async.test.ts
+++ b/tests/async/async.test.ts
@@ -174,8 +174,8 @@ describe("Resonate — async/await engine", () => {
 
     await (await resonate.run("createorder", fanout)).result();
 
-    const children = recording.creates.filter((id) => id.startsWith("createorder."));
-    expect(children).toEqual(["createorder.0", "createorder.1", "createorder.2", "createorder.3"]);
+    const children = recording.creates.filter((id) => id.startsWith("createorder:"));
+    expect(children).toEqual(["createorder:0", "createorder:1", "createorder:2", "createorder:3"]);
   });
 
   test("hang model: a suspending pass never enters the surrounding try/catch", async () => {
@@ -286,8 +286,8 @@ describe("Resonate — async/await engine", () => {
     resonate.register("dpcwf", wf);
 
     const handle = await resonate.run("dpc-1", wf);
-    await sleep(100); // ensure the latent promise dpc-1.0 has been created
-    await resonate.promises.resolve("dpc-1.0", { data: codec.encode("signal").data });
+    await sleep(100); // ensure the latent promise dpc-1:0 has been created
+    await resonate.promises.resolve("dpc-1:0", { data: codec.encode("signal").data });
 
     expect(await handle.result()).toBe("signal");
   });
@@ -323,10 +323,10 @@ describe("Resonate — async/await engine", () => {
     await (await resonate.run("prefix-1", wf)).result();
 
     expect(recording.tags.get("prefix-1")?.["resonate:prefix"]).toBe("prefix-1"); // root
-    expect(recording.tags.get("prefix-1.0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
-    expect(recording.tags.get("prefix-1.1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
-    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1.d"));
-    expect(detachedId).toMatch(/^prefix-1\.d[0-9a-f]{14}$/);
+    expect(recording.tags.get("prefix-1:0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
+    expect(recording.tags.get("prefix-1:1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
+    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1:d"));
+    expect(detachedId).toMatch(/^prefix-1:d[0-9a-f]{14}$/);
     expect(recording.tags.get(detachedId as string)?.["resonate:prefix"]).toBe("prefix-1");
   });
 
@@ -352,8 +352,8 @@ describe("Resonate — async/await engine", () => {
     // Every level keeps the top-level root as its id-generation prefix, so each
     // detached id is exactly one `.d` segment past it — bounded at any depth.
     for (const s of seen) expect(s.prefixId).toBe("nest-root");
-    expect(seen[1].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
-    expect(seen[2].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
+    expect(seen[1].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
+    expect(seen[2].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
     // The detached re-root breaks lineage: origin resets to its own id.
     expect(seen[1].originId).toBe(seen[1].id);
   });
@@ -420,7 +420,7 @@ describe("Resonate — async/await engine", () => {
 
     // Neither the root nor the (created) child promise settles.
     expect((await resonate.promises.get("panic-3")).state).toBe("pending");
-    expect((await resonate.promises.get("panic-3.0")).state).toBe("pending");
+    expect((await resonate.promises.get("panic-3:0")).state).toBe("pending");
   });
 
   test("ctx.panic(false) and ctx.assert(true) do not abort", async () => {

--- a/tests/async/async.test.ts
+++ b/tests/async/async.test.ts
@@ -307,8 +307,6 @@ describe("Resonate — async/await engine", () => {
     expect(await (await resonate.get<number>(childId)).result()).toBe(50);
   });
 
-
-
   test("ctx.panic aborts the pass: execution stops and nothing settles", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});
     jest.spyOn(console, "warn").mockImplementation(() => {});

--- a/tests/async/async.test.ts
+++ b/tests/async/async.test.ts
@@ -307,56 +307,7 @@ describe("Resonate — async/await engine", () => {
     expect(await (await resonate.get<number>(childId)).result()).toBe(50);
   });
 
-  test("resonate:prefix is set at the root and propagates to every child create", async () => {
-    const recording = new RecordingNetwork(new LocalNetwork({ pid: "default", group: "default" }));
-    resonate = new Resonate({ network: recording, ttl: Number.MAX_SAFE_INTEGER });
-    resonate.register("pchild", async (_info: Info, n: number): Promise<number> => n);
-    resonate.register("pdet", async (_info: Info): Promise<void> => {});
-    const wf = async (ctx: Context): Promise<number> => {
-      const v = await ctx.run<number>("pchild", 7);
-      await ctx.sleep(1);
-      await ctx.detached("pdet");
-      return v;
-    };
-    resonate.register("prefixwf", wf);
 
-    await (await resonate.run("prefix-1", wf)).result();
-
-    expect(recording.tags.get("prefix-1")?.["resonate:prefix"]).toBe("prefix-1"); // root
-    expect(recording.tags.get("prefix-1:0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
-    expect(recording.tags.get("prefix-1:1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
-    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1:d"));
-    expect(detachedId).toMatch(/^prefix-1:d[0-9a-f]{14}$/);
-    expect(recording.tags.get(detachedId as string)?.["resonate:prefix"]).toBe("prefix-1");
-  });
-
-  test("nested detached ids stay bounded via the fixed prefix", async () => {
-    resonate = newResonate();
-    const seen: { id: string; prefixId: string; originId: string }[] = [];
-    const deepest = Promise.withResolvers<void>();
-    const nest = async (ctx: Context, depth: number): Promise<void> => {
-      seen.push({ id: ctx.id, prefixId: ctx.prefixId, originId: ctx.originId });
-      if (depth >= 3) {
-        deepest.resolve();
-        return;
-      }
-      await ctx.detached("nest", depth + 1);
-    };
-    resonate.register("nest", nest);
-
-    await (await resonate.run("nest-root", nest, 1)).result();
-    await deepest.promise;
-
-    expect(seen).toHaveLength(3);
-    expect(seen[0].id).toBe("nest-root");
-    // Every level keeps the top-level root as its id-generation prefix, so each
-    // detached id is exactly one `.d` segment past it — bounded at any depth.
-    for (const s of seen) expect(s.prefixId).toBe("nest-root");
-    expect(seen[1].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
-    expect(seen[2].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
-    // The detached re-root breaks lineage: origin resets to its own id.
-    expect(seen[1].originId).toBe(seen[1].id);
-  });
 
   test("ctx.panic aborts the pass: execution stops and nothing settles", async () => {
     jest.spyOn(console, "error").mockImplementation(() => {});

--- a/tests/async/core.test.ts
+++ b/tests/async/core.test.ts
@@ -59,7 +59,7 @@ function buildCore(fns: Record<string, AnyFunc>): {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (t: string) => t, idPrefix: "test-" }),
+    optsBuilder: new OptionsBuilder({ match: (t: string) => t }),
     logger: new ConsoleLogger("error"),
   });
 

--- a/tests/async/core.test.ts
+++ b/tests/async/core.test.ts
@@ -212,16 +212,16 @@ describe("AsyncCore", () => {
 
       expect(res.kind).toBe("suspended");
       if (res.kind === "suspended") {
-        expect(res.awaited).toContain("p4.0");
-        expect(res.awaited).toContain("p4.1");
+        expect(res.awaited).toContain("p4:0");
+        expect(res.awaited).toContain("p4:1");
       }
 
       const suspend = sent.find((r) => r.kind === "task.suspend");
       expect(suspend).toBeDefined();
       if (suspend && suspend.kind === "task.suspend") {
         const awaitedIds = suspend.data.actions.map((a) => a.data.awaited);
-        expect(awaitedIds).toContain("p4.0");
-        expect(awaitedIds).toContain("p4.1");
+        expect(awaitedIds).toContain("p4:0");
+        expect(awaitedIds).toContain("p4:1");
       }
     });
 
@@ -244,7 +244,7 @@ describe("AsyncCore", () => {
           await origFn({
             kind: "promise.settle",
             head: { corrId: randomUUID(), version: VERSION },
-            data: { id: "p5.0", state: "resolved", value: codec.encode(7) },
+            data: { id: "p5:0", state: "resolved", value: codec.encode(7) },
           });
           return {
             kind: "task.suspend",
@@ -357,7 +357,7 @@ describe("AsyncCore", () => {
       const fence = creates[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-1.0");
+      expect(fence.data.action.data.id).toBe("fence-1:0");
 
       // Ensure no bare promise.create was sent during execution
       expect(sent.some((r) => r.kind === "promise.create")).toBe(false);
@@ -380,7 +380,7 @@ describe("AsyncCore", () => {
       const fence = settles[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-2.0");
+      expect(fence.data.action.data.id).toBe("fence-2:0");
 
       // No bare promise.settle should have been sent during execution
       expect(sent.some((r) => r.kind === "promise.settle")).toBe(false);

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -100,11 +100,11 @@ describe("Resonate usage tests", () => {
   test("test lineage rfc", async () => {
     resonate = newResonate();
     const baz = async (_info: Info): Promise<string> => {
-      // origin: foo.1 / parent: foo.1.0 / branch: foo.1.0.0
+      // origin: foo.1 / parent: foo.1:0 / branch: foo.1:0.0
       return "hello";
     };
     const bar = async (ctx: Context): Promise<string> => {
-      // origin: foo.1 / parent: foo.1 / branch: foo.1.0
+      // origin: foo.1 / parent: foo.1 / branch: foo.1:0
       return ctx.rpc<string>("baz");
     };
     const foo = async (ctx: Context): Promise<string> => {
@@ -124,19 +124,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
+      "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+      "resonate:branch": "foo.1:0.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -158,18 +158,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
     });
   });
@@ -185,8 +185,8 @@ describe("Resonate usage tests", () => {
     const h = await resonate.run("done-1", wf);
     expect(await h.done()).toBe(false);
 
-    await sleep(100); // ensure the latent promise done-1.0 exists
-    await resonate.promises.resolve("done-1.0", { data: codec.encode("v").data });
+    await sleep(100); // ensure the latent promise done-1:0 exists
+    await resonate.promises.resolve("done-1:0", { data: codec.encode("v").data });
     expect(await h.result()).toBe("v");
     expect(await h.done()).toBe(true);
 
@@ -349,15 +349,15 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("opts-1.0");
+      expect(fu.id).toBe("opts-1:0");
       return fu;
     };
     resonate.register("optswf", wf);
 
     const v = await res(resonate.run("opts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("opts-1.0");
-    expect(durable.id).toBe("opts-1.0");
+    const durable = await resonate.promises.get("opts-1:0");
+    expect(durable.id).toBe("opts-1:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
   });
 
@@ -370,15 +370,15 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function");
-      expect(fu.id).toBe("noopts-1.0");
+      expect(fu.id).toBe("noopts-1:0");
       return fu;
     };
     resonate.register("nooptswf", wf);
 
     const v = await res(resonate.run("noopts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("noopts-1.0");
-    expect(durable.id).toBe("noopts-1.0");
+    const durable = await resonate.promises.get("noopts-1:0");
+    expect(durable.id).toBe("noopts-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "noopts-1",
@@ -400,7 +400,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await res(resonate.rpc(`t${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`t${i}`);
-      const p2 = await resonate.promises.get(`t${i}.0`);
+      const p2 = await resonate.promises.get(`t${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -418,7 +418,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await res(resonate.rpc(`u${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`u${i}`);
-      const p2 = await resonate.promises.get(`u${i}.0`);
+      const p2 = await resonate.promises.get(`u${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -430,18 +430,18 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>();
-      expect(fu.id).toBe("hitl-1.0");
+      expect(fu.id).toBe("hitl-1:0");
       return fu;
     };
     resonate.register("hitlwf", wf);
 
     const h = await resonate.run("hitl-1", wf);
-    await sleep(100); // ensure hitl-1.0 promise is created
+    await sleep(100); // ensure hitl-1:0 promise is created
 
-    await resonate.promises.resolve("hitl-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("hitl-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
-    expect((await resonate.promises.get("hitl-1.0")).tags).toEqual({
-      "resonate:branch": "hitl-1.0",
+    expect((await resonate.promises.get("hitl-1:0")).tags).toEqual({
+      "resonate:branch": "hitl-1:0",
       "resonate:origin": "hitl-1",
       "resonate:prefix": "hitl-1",
       "resonate:parent": "hitl-1",
@@ -456,25 +456,25 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("timeout-1.0");
+      expect(fu.id).toBe("timeout-1:0");
       return fu;
     };
     resonate.register("timeoutwf", wf);
 
     const h = await resonate.run("timeout-1", wf);
-    await sleep(100); // ensure timeout-1.0 promise is created
+    await sleep(100); // ensure timeout-1:0 promise is created
 
-    const durable = await resonate.promises.get("timeout-1.0");
+    const durable = await resonate.promises.get("timeout-1:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "timeout-1.0",
+      "resonate:branch": "timeout-1:0",
       "resonate:origin": "timeout-1",
       "resonate:prefix": "timeout-1",
       "resonate:parent": "timeout-1",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("timeout-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("timeout-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
   });
 
@@ -489,12 +489,12 @@ describe("Resonate usage tests", () => {
     resonate.register("sleepwf", wf);
 
     const h = await resonate.run("sleep-1", wf);
-    await sleep(100); // ensure sleep-1.0 promise is created
+    await sleep(100); // ensure sleep-1:0 promise is created
 
-    const durable = await resonate.promises.get("sleep-1.0");
+    const durable = await resonate.promises.get("sleep-1:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "sleep-1.0",
+      "resonate:branch": "sleep-1:0",
       "resonate:origin": "sleep-1",
       "resonate:prefix": "sleep-1",
       "resonate:parent": "sleep-1",
@@ -581,11 +581,11 @@ describe("Resonate usage tests", () => {
     resonate.register("twf1", wf);
 
     await res(resonate.run("tdef-1", wf));
-    const durable = await resonate.promises.get("tdef-1.0");
-    expect(durable.id).toBe("tdef-1.0");
+    const durable = await resonate.promises.get("tdef-1:0");
+    expect(durable.id).toBe("tdef-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "tdef-1.0",
+      "resonate:branch": "tdef-1:0",
       "resonate:parent": "tdef-1",
       "resonate:origin": "tdef-1",
       "resonate:prefix": "tdef-1",
@@ -604,10 +604,10 @@ describe("Resonate usage tests", () => {
     resonate.register("twf2", wf);
 
     await res(resonate.run("topt-1", wf));
-    const durable = await resonate.promises.get("topt-1.0");
+    const durable = await resonate.promises.get("topt-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "topt-1.0",
+      "resonate:branch": "topt-1:0",
       "resonate:parent": "topt-1",
       "resonate:origin": "topt-1",
       "resonate:prefix": "topt-1",
@@ -626,10 +626,10 @@ describe("Resonate usage tests", () => {
     resonate.register("twf3", wf);
 
     await res(resonate.run("turl-1", wf));
-    const durable = await resonate.promises.get("turl-1.0");
+    const durable = await resonate.promises.get("turl-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "turl-1.0",
+      "resonate:branch": "turl-1:0",
       "resonate:parent": "turl-1",
       "resonate:origin": "turl-1",
       "resonate:prefix": "turl-1",
@@ -830,7 +830,7 @@ describe("Resonate usage tests", () => {
     // awaited out of band by id.
     expect(new Set(ids).size).toBe(2);
     for (const id of ids) {
-      expect(id).toMatch(/^equiv-1\.d[0-9a-f]+$/);
+      expect(id).toMatch(/^equiv-1:d[0-9a-f]+$/);
       expect(await (await resonate.get<string>(id)).result()).toBe("bar");
     }
   });

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -819,7 +819,6 @@ describe("Resonate usage tests", () => {
       expect(await (await resonate.get<string>(id)).result()).toBe("bar");
     }
   });
-
 });
 
 describe("Resonate environment variable initialization", () => {

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -118,7 +118,6 @@ describe("Resonate usage tests", () => {
     expect(await res(resonate.run("foo.1", foo))).toBe("hello");
     expect((await resonate.promises.get("foo.1")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -126,7 +125,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -134,7 +132,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1:0.0",
       "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
@@ -152,7 +149,6 @@ describe("Resonate usage tests", () => {
     expect(await res(f.run("foo.1"))).toBe("hello");
     expect((await resonate.promises.get("foo.1")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -160,14 +156,12 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
     expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
@@ -384,7 +378,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "noopts-1",
       "resonate:parent": "noopts-1",
       "resonate:origin": "noopts-1",
-      "resonate:prefix": "noopts-1",
     });
   });
 
@@ -443,7 +436,6 @@ describe("Resonate usage tests", () => {
     expect((await resonate.promises.get("hitl-1:0")).tags).toEqual({
       "resonate:branch": "hitl-1:0",
       "resonate:origin": "hitl-1",
-      "resonate:prefix": "hitl-1",
       "resonate:parent": "hitl-1",
       "resonate:scope": "global",
     });
@@ -470,7 +462,6 @@ describe("Resonate usage tests", () => {
     expect(durable.tags).toEqual({
       "resonate:branch": "timeout-1:0",
       "resonate:origin": "timeout-1",
-      "resonate:prefix": "timeout-1",
       "resonate:parent": "timeout-1",
       "resonate:scope": "global",
     });
@@ -496,7 +487,6 @@ describe("Resonate usage tests", () => {
       "resonate:timer": "true",
       "resonate:branch": "sleep-1:0",
       "resonate:origin": "sleep-1",
-      "resonate:prefix": "sleep-1",
       "resonate:parent": "sleep-1",
       "resonate:scope": "global",
     });
@@ -588,7 +578,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "tdef-1:0",
       "resonate:parent": "tdef-1",
       "resonate:origin": "tdef-1",
-      "resonate:prefix": "tdef-1",
       "resonate:target": "local://any@default",
     });
   });
@@ -610,7 +599,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "topt-1:0",
       "resonate:parent": "topt-1",
       "resonate:origin": "topt-1",
-      "resonate:prefix": "topt-1",
       "resonate:target": "local://any@remoteTarget",
     });
   });
@@ -632,7 +620,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "turl-1:0",
       "resonate:parent": "turl-1",
       "resonate:origin": "turl-1",
-      "resonate:prefix": "turl-1",
       "resonate:target": "http://faasurl.com",
     });
   });
@@ -654,7 +641,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "troot-1",
       "resonate:parent": "troot-1",
       "resonate:origin": "troot-1",
-      "resonate:prefix": "troot-1",
       "resonate:target": "http://faasurl.com",
     });
   });
@@ -675,7 +661,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "troot-2",
       "resonate:parent": "troot-2",
       "resonate:origin": "troot-2",
-      "resonate:prefix": "troot-2",
       "resonate:target": "local://any@default",
     });
   });
@@ -835,42 +820,6 @@ describe("Resonate usage tests", () => {
     }
   });
 
-  test("Using prefix at Resonate class prefixes all the promises", async () => {
-    const prefix = "myPrefix";
-    resonate = new Resonate({ prefix });
-
-    const qux = async (info: Info): Promise<string> => {
-      expect(info.id.startsWith(prefix)).toBe(true);
-      expect(info.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "qux";
-    };
-
-    const baz = async (ctx: Context): Promise<string> => {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      await ctx.run(qux);
-      return "baz";
-    };
-
-    const bar = async (ctx: Context): Promise<string> => {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "bar";
-    };
-
-    const foo = async (ctx: Context): Promise<string> => {
-      const p = ctx.run(bar);
-      await ctx.run(baz);
-      await ctx.run(qux);
-      await p;
-      return "ok";
-    };
-    const f = resonate.register("pfxfoo", foo);
-
-    const h = await f.run("fooId");
-    expect(h.id).toBe(`${prefix}:fooId`);
-    expect(await h.result()).toBe("ok");
-  });
 });
 
 describe("Resonate environment variable initialization", () => {

--- a/tests/async/structured-concurrency.test.ts
+++ b/tests/async/structured-concurrency.test.ts
@@ -127,8 +127,8 @@ describe("async engine structured concurrency", () => {
       expect(status.kind).toBe("done");
       if (status.kind !== "done") return;
       expect(status.value).toBe("done");
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire.0");
-      const rec = await getPromise(network, "sc-fire.0");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire:0");
+      const rec = await getPromise(network, "sc-fire:0");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("side-effect");
     } finally {
@@ -142,10 +142,10 @@ describe("async engine structured concurrency", () => {
       const leafA = async (_i: Info) => "a";
       const leafB = async (_i: Info, x: string) => `b:${x}`;
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-local.0 — pending remote, ends the pass
+        const timer = ctx.sleep(60_000); // sc-local:0 — pending remote, ends the pass
         const chained = (async () => {
-          const x = await ctx.run<string>("leafA"); // sc-local.1
-          return ctx.run<string>("leafB", x); // sc-local.2 — starts mid-drain
+          const x = await ctx.run<string>("leafA"); // sc-local:1
+          return ctx.run<string>("leafB", x); // sc-local:2 — starts mid-drain
         })();
         await Promise.all([timer, chained]);
         return "done";
@@ -156,13 +156,13 @@ describe("async engine structured concurrency", () => {
       // The pass suspends on the timer only; the chained locals both completed.
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-local.0"]);
+      expect(status.awaited).toEqual(["sc-local:0"]);
 
       // The chained run finished INSIDE the pass: its return event is in the
       // trace (not emitted after getTrace) and its durable promise is settled
       // before executeUntilBlocked returned (no settle racing task.suspend).
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local.2");
-      const rec = await getPromise(network, "sc-local.2");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local:2");
+      const rec = await getPromise(network, "sc-local:2");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("b:a");
     } finally {
@@ -175,10 +175,10 @@ describe("async engine structured concurrency", () => {
     try {
       const leafA = async (_i: Info) => "a";
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-remote.0
+        const timer = ctx.sleep(60_000); // sc-remote:0
         const chained = (async () => {
-          await ctx.run<string>("leafA"); // sc-remote.1
-          return ctx.rpc<string>("remoteB"); // sc-remote.2 — remote, pending
+          await ctx.run<string>("leafA"); // sc-remote:1
+          return ctx.rpc<string>("remoteB"); // sc-remote:2 — remote, pending
         })();
         await Promise.all([timer, chained]);
       };
@@ -189,7 +189,7 @@ describe("async engine structured concurrency", () => {
       // todo was lost (self-healing on resume, but a missed callback).
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect([...status.awaited].sort()).toEqual(["sc-remote.0", "sc-remote.2"]);
+      expect([...status.awaited].sort()).toEqual(["sc-remote:0", "sc-remote:2"]);
     } finally {
       await network.stop();
     }
@@ -201,13 +201,13 @@ describe("async engine structured concurrency", () => {
       const leafA = async (_i: Info) => "a";
       const leafB = async (_i: Info) => "b";
       const wf = async (ctx: Context) => {
-        const timer = ctx.sleep(60_000); // sc-hops.0
+        const timer = ctx.sleep(60_000); // sc-hops:0
         const chained = (async () => {
-          await ctx.run<string>("leafA"); // sc-hops.1
+          await ctx.run<string>("leafA"); // sc-hops:1
           await null; // non-durable microtask hops between durable ops
           await null;
           await null;
-          return ctx.run<string>("leafB"); // sc-hops.2
+          return ctx.run<string>("leafB"); // sc-hops:2
         })();
         await Promise.all([timer, chained]);
       };
@@ -216,9 +216,9 @@ describe("async engine structured concurrency", () => {
 
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-hops.0"]);
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops.2");
-      expect((await getPromise(network, "sc-hops.2"))?.state).toBe("resolved");
+      expect(status.awaited).toEqual(["sc-hops:0"]);
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops:2");
+      expect((await getPromise(network, "sc-hops:2"))?.state).toBe("resolved");
     } finally {
       await network.stop();
     }
@@ -238,7 +238,7 @@ describe("async engine structured concurrency", () => {
             leaked = e;
           }
         })();
-        await ctx.sleep(60_000); // sc-zombie.0 — the pass suspends here
+        await ctx.sleep(60_000); // sc-zombie:0 — the pass suspends here
       };
 
       const status = await runRoot(network, { "sc-zombie": wf, leafA }, "sc-zombie");
@@ -247,7 +247,7 @@ describe("async engine structured concurrency", () => {
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
       // The panicked op never reached the server: no child promise was created.
-      expect(await getPromise(network, "sc-zombie.1")).toBeUndefined();
+      expect(await getPromise(network, "sc-zombie:1")).toBeUndefined();
     } finally {
       await network.stop();
     }
@@ -276,7 +276,7 @@ describe("async engine structured concurrency", () => {
 
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
-      expect(await getPromise(network, "sc-done.0")).toBeUndefined();
+      expect(await getPromise(network, "sc-done:0")).toBeUndefined();
     } finally {
       await network.stop();
     }

--- a/tests/async/structured-concurrency.test.ts
+++ b/tests/async/structured-concurrency.test.ts
@@ -50,7 +50,7 @@ function newCore(registry: Registry, network: LocalNetwork): Core {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (target: string) => target, idPrefix: "" }),
+    optsBuilder: new OptionsBuilder({ match: (target: string) => target }),
     logger: new ConsoleLogger("error"),
   });
 }

--- a/tests/computation.test.ts
+++ b/tests/computation.test.ts
@@ -66,7 +66,7 @@ async function buildComputation(registry: Registry): Promise<{
     registry,
     new TestHeartbeat(),
     new Map(),
-    new OptionsBuilder({ match: (target: string) => target, idPrefix: "test-" }),
+    new OptionsBuilder({ match: (target: string) => target }),
     logger,
   );
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -76,7 +76,7 @@ function buildCore(opts: {
     registry: new Registry(),
     heartbeat: new TestHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (t: string) => t, idPrefix: "test-" }),
+    optsBuilder: new OptionsBuilder({ match: (t: string) => t }),
     logger,
   });
 

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -355,8 +355,6 @@ describe("Coroutine", () => {
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
-
-
   test("detached breaks the origin lineage and starts a new one, even with an explicit id", () => {
     // "detached" is fire-and-forget and runs as its own root, so resonate:origin
     // is reset to its own id (origin == id == branch) -- a fresh lineage -- even

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -191,7 +191,7 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
@@ -211,14 +211,14 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:0", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
@@ -274,7 +274,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     // Second execution: everything resolved → done
     r = await exec("foo.1", foo, [], effects);
@@ -319,7 +319,7 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:0", { kind: "value", value: 42 });
     r = await exec("foo.1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
@@ -342,14 +342,14 @@ describe("Coroutine", () => {
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
-    await completePromise(effects, `${id}.0`, { kind: "value", value: 42 });
+    await completePromise(effects, `${id}:0`, { kind: "value", value: 42 });
     r = await exec(id, foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, util.detachedId(id, `${id}.1`), { kind: "value", value: 42 });
+    await completePromise(effects, util.detachedId(id, `${id}:1`), { kind: "value", value: 42 });
     r = await exec(id, foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
@@ -359,10 +359,10 @@ describe("Coroutine", () => {
     // A detached workflow runs as its own root: resonate:origin is reset to its
     // own id (a fresh lineage). Recursive detached ids stay bounded NOT via
     // origin but via resonate:prefix, propagated unchanged across re-roots. Were
-    // the id minted off the (grown) origin, each level would add a `.d${hash}`
+    // the id minted off the (grown) origin, each level would add a `:d${hash}`
     // segment without bound; rooting it on the pinned prefix keeps it at
-    // `${prefix}.d${hash}` -- one segment past the prefix, at every depth.
-    const grownId = "top.deadbeefdeadbe"; // a workflow already several detached levels deep
+    // `${prefix}:d${hash}` -- one segment past the prefix, at every depth.
+    const grownId = "top:deadbeefdeadbe"; // a workflow already several detached levels deep
     const ctx = new InnerContext({
       id: grownId,
       oId: grownId, // detached re-roots origin to its own (grown) id
@@ -381,9 +381,9 @@ describe("Coroutine", () => {
 
     // The detached id is rooted at the pinned PREFIX "top", exactly one segment
     // past it -- NOT the grown id (which would add a segment per level).
-    expect(rfi.id).toBe(util.detachedId("top", `${grownId}.0`));
-    expect(rfi.id.startsWith("top.d")).toBe(true);
-    expect(rfi.id.split(".")).toHaveLength(2);
+    expect(rfi.id).toBe(util.detachedId("top", `${grownId}:0`));
+    expect(rfi.id.startsWith("top:d")).toBe(true);
+    expect(rfi.id.split(":")).toHaveLength(2);
 
     // The prefix carries forward unchanged, bounding the next level; the child's
     // lineage origin is its OWN id (a fresh lineage root).
@@ -396,10 +396,10 @@ describe("Coroutine", () => {
     // re-rooting each child exactly as production does -- a detached promise
     // executes as its own root with oId = its resonate:origin tag (its own id)
     // and prId = its resonate:prefix tag (computation.ts). The id is
-    // `${prefix}.d${cyrb53(seqid).padStart(14)}`: the hash flattens the
+    // `${prefix}:d${cyrb53(seqid).padStart(14)}`: the hash flattens the
     // (ever-growing) seqid to a constant 14 chars, and the prefix tag keeps the
     // prefix pinned to the top, so it never grows. Net: every detached id at
-    // every depth is exactly `${top}.d${14hex}` -- bounded regardless of depth.
+    // every depth is exactly `${top}:d${14hex}` -- bounded regardless of depth.
     const makeCtx = (id: string, oId: string, prId: string) =>
       new InnerContext({
         id,
@@ -445,9 +445,9 @@ describe("Coroutine", () => {
       frontier = next;
     }
 
-    // Bounded: a single length across all depths, exactly `${top}.d${14hex}`.
+    // Bounded: a single length across all depths, exactly `${top}:d${14hex}`.
     expect(lengths.size).toBe(1);
-    expect([...lengths][0]).toBe(TOP.length + ".d".length + 14);
+    expect([...lengths][0]).toBe(TOP.length + ":d".length + 14);
     // ...and no collisions: every node in the tree got a distinct id.
     expect(ids.size).toBe((FANOUT ** (DEPTH + 1) - FANOUT) / (FANOUT - 1));
   });
@@ -499,7 +499,7 @@ describe("Coroutine", () => {
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     r = await exec("foo.1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 84 } });
@@ -632,7 +632,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise that the child was waiting on
-    await completePromise(effects, "foo.1.0.0", { kind: "value", value: 21 });
+    await completePromise(effects, "foo.1:0.0", { kind: "value", value: 21 });
 
     // Second execution: child completes → parent completes
     r = await exec("foo.1", parent, [], effects);
@@ -658,7 +658,7 @@ describe("Coroutine", () => {
     expect(r.type).toBe("suspended");
 
     // Settle remote
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo.1:1", { kind: "value", value: 42 });
 
     // Re-execution: local promise already settled (fast-forward), completes
     r = await exec("foo.1", foo, [], effects);
@@ -698,8 +698,8 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote.length).toBeGreaterThanOrEqual(2);
 
     // Settle both remote promises
-    await completePromise(effects, "p.1.0", { kind: "value", value: 5 });
-    await completePromise(effects, "p.1.1.0", { kind: "value", value: 3 });
+    await completePromise(effects, "p.1:0", { kind: "value", value: 5 });
+    await completePromise(effects, "p.1:1.0", { kind: "value", value: 3 });
 
     // Second execution: everything settled → done
     r = await exec("p.1", parent, [], effects);
@@ -730,7 +730,7 @@ describe("Coroutine", () => {
     expect(suspended.todo.remote).toHaveLength(1); // only remoteParent
 
     // Settle the remote
-    await completePromise(effects, "p.1.0", { kind: "value", value: 8 });
+    await completePromise(effects, "p.1:0", { kind: "value", value: 8 });
 
     // Second execution: bar's durable promise was settled on first run → replay fast-path
     r = await exec("p.1", parent, [], effects);

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -98,7 +98,7 @@ describe("Coroutine", () => {
         timeout: 0,
         version: 1,
         retryPolicy: new Never(),
-        optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+        optsBuilder: new OptionsBuilder({ match: (t) => t }),
       }),
       func,
       args,
@@ -355,113 +355,16 @@ describe("Coroutine", () => {
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
-  test("detached id stays bounded across recursive re-root", () => {
-    // A detached workflow runs as its own root: resonate:origin is reset to its
-    // own id (a fresh lineage). Recursive detached ids stay bounded NOT via
-    // origin but via resonate:prefix, propagated unchanged across re-roots. Were
-    // the id minted off the (grown) origin, each level would add a `:d${hash}`
-    // segment without bound; rooting it on the pinned prefix keeps it at
-    // `${prefix}:d${hash}` -- one segment past the prefix, at every depth.
-    const grownId = "top:deadbeefdeadbe"; // a workflow already several detached levels deep
-    const ctx = new InnerContext({
-      id: grownId,
-      oId: grownId, // detached re-roots origin to its own (grown) id
-      prId: "top", // the id-generation prefix is still pinned to the top
-      func: "fires",
-      clock: new WallClock(),
-      registry: new Registry(),
-      dependencies: new Map(),
-      timeout: 0,
-      version: 1,
-      retryPolicy: new Never(),
-      optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
-    });
 
-    const rfi = ctx.detached("fires");
-
-    // The detached id is rooted at the pinned PREFIX "top", exactly one segment
-    // past it -- NOT the grown id (which would add a segment per level).
-    expect(rfi.id).toBe(util.detachedId("top", `${grownId}:0`));
-    expect(rfi.id.startsWith("top:d")).toBe(true);
-    expect(rfi.id.split(":")).toHaveLength(2);
-
-    // The prefix carries forward unchanged, bounding the next level; the child's
-    // lineage origin is its OWN id (a fresh lineage root).
-    expect(rfi.createReq.data.tags?.["resonate:prefix"]).toBe("top");
-    expect(rfi.createReq.data.tags?.["resonate:origin"]).toBe(rfi.id);
-  });
-
-  test("recursive multi-detached keeps every id at the same bounded length", () => {
-    // End-to-end proof: fan out FANOUT detached per workflow, DEPTH levels deep,
-    // re-rooting each child exactly as production does -- a detached promise
-    // executes as its own root with oId = its resonate:origin tag (its own id)
-    // and prId = its resonate:prefix tag (computation.ts). The id is
-    // `${prefix}:d${cyrb53(seqid).padStart(14)}`: the hash flattens the
-    // (ever-growing) seqid to a constant 14 chars, and the prefix tag keeps the
-    // prefix pinned to the top, so it never grows. Net: every detached id at
-    // every depth is exactly `${top}:d${14hex}` -- bounded regardless of depth.
-    const makeCtx = (id: string, oId: string, prId: string) =>
-      new InnerContext({
-        id,
-        oId,
-        prId,
-        func: "fires",
-        clock: new WallClock(),
-        registry: new Registry(),
-        dependencies: new Map(),
-        timeout: 0,
-        version: 1,
-        retryPolicy: new Never(),
-        optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
-      });
-
-    const TOP = "top";
-    const FANOUT = 3;
-    const DEPTH = 4;
-
-    // Frontier of workflows to run; seed with the genuine top-level root
-    // (origin == prefix == its id).
-    let frontier: Array<{ id: string; oId: string; prId: string }> = [{ id: TOP, oId: TOP, prId: TOP }];
-    const lengths = new Set<number>();
-    const ids = new Set<string>();
-
-    for (let level = 0; level < DEPTH; level++) {
-      const next: Array<{ id: string; oId: string; prId: string }> = [];
-      for (const { id, oId, prId } of frontier) {
-        const ctx = makeCtx(id, oId, prId);
-        for (let i = 0; i < FANOUT; i++) {
-          const rfi = ctx.detached("fires");
-          lengths.add(rfi.id.length);
-          ids.add(rfi.id);
-          // Re-root as production does: oId = origin tag (its own id), prId =
-          // prefix tag (the top, propagated unchanged -- what bounds the id).
-          next.push({
-            id: rfi.id,
-            oId: rfi.createReq.data.tags?.["resonate:origin"] as string,
-            prId: rfi.createReq.data.tags?.["resonate:prefix"] as string,
-          });
-        }
-      }
-      frontier = next;
-    }
-
-    // Bounded: a single length across all depths, exactly `${top}:d${14hex}`.
-    expect(lengths.size).toBe(1);
-    expect([...lengths][0]).toBe(TOP.length + ":d".length + 14);
-    // ...and no collisions: every node in the tree got a distinct id.
-    expect(ids.size).toBe((FANOUT ** (DEPTH + 1) - FANOUT) / (FANOUT - 1));
-  });
 
   test("detached breaks the origin lineage and starts a new one, even with an explicit id", () => {
     // "detached" is fire-and-forget and runs as its own root, so resonate:origin
     // is reset to its own id (origin == id == branch) -- a fresh lineage -- even
-    // with a caller-pinned id. The id-generation prefix (resonate:prefix) is
-    // carried forward unchanged, independent of the diverging origin.
-    const optsBuilder = new OptionsBuilder({ match: (t) => t, idPrefix: "" });
+    // with a caller-pinned id.
+    const optsBuilder = new OptionsBuilder({ match: (t) => t });
     const ctx = new InnerContext({
       id: "wf",
       oId: "top",
-      prId: "top",
       func: "fires",
       clock: new WallClock(),
       registry: new Registry(),
@@ -475,9 +378,8 @@ describe("Coroutine", () => {
     const rfi = ctx.detached("fires", optsBuilder.build({ id: "custom-detached" }));
 
     expect(rfi.id).toBe("custom-detached");
-    // Origin is the detached's own id (new lineage); prefix is propagated.
+    // Origin is the detached's own id (a fresh lineage).
     expect(rfi.createReq.data.tags?.["resonate:origin"]).toBe("custom-detached");
-    expect(rfi.createReq.data.tags?.["resonate:prefix"]).toBe("top");
   });
 
   test("lfc/rfc", async () => {
@@ -529,7 +431,7 @@ describe("Coroutine", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (t) => t }),
         }),
         foo,
         [],

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -42,7 +42,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -90,7 +90,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -165,7 +165,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -220,7 +220,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -287,7 +287,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -356,7 +356,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -390,7 +390,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -427,7 +427,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -493,7 +493,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -551,7 +551,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -50,7 +50,7 @@ describe("Decorator", () => {
 
     expect(r).toMatchObject({
       type: "internal.async.l",
-      id: "foo.0",
+      id: "foo:0",
     });
   });
 
@@ -177,14 +177,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     }); // pending promise → generator gets Future(pending), advances to second LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -231,7 +231,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -243,14 +243,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.1",
+      id: "foo:1",
     }); // B -> pending promise → generator gets Future(pending), advances to C -> LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -298,7 +298,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -309,7 +309,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 20 },
@@ -320,7 +320,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -507,10 +507,10 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     // Generator advances to yield* f (Future iterator: yield this)
-    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo.0" } });
+    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo:0" } });
 
     // Coroutine resolves inline and feeds a literal back
     r = d.next({
@@ -565,7 +565,7 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending" } });
 

--- a/tests/equivalence/equivalence.test.ts
+++ b/tests/equivalence/equivalence.test.ts
@@ -16,9 +16,7 @@ describe("engine equivalence (generator vs async)", () => {
   test("sleep", () => expectEquivalent(sleep), 30_000);
   test("human-in-the-loop (DPC)", () => expectEquivalent(humanInTheLoop), 30_000);
 
-  // Detached id is hashed from prefixId (generator) vs originId (async). For a
-  // top-level parent those coincide, so this currently passes; a nested-detached
-  // variant would surface the divergence. Kept as a live test to catch a
-  // regression either way.
+  // Detached id is hashed from the lineage origin id in both engines, so they
+  // agree. Kept as a live test to catch a regression either way.
   test("detached", () => expectEquivalent(detached), 30_000);
 });

--- a/tests/equivalence/oracle.ts
+++ b/tests/equivalence/oracle.ts
@@ -24,9 +24,7 @@ type Snap200 = Extract<DebugSnapRes, { head: { status: 200 } }>["data"];
 export type SnapMode = "wallclock" | "stepclock";
 
 /** Tags that legitimately differ between the engines and are excluded from the
- * canonical projection. Currently empty: `resonate:prefix` used to be excluded
- * (former divergence #5) but the async engine now sets and propagates it
- * identically, so it is compared like every other tag. */
+ * canonical projection. Currently empty. */
 const DEFAULT_STRIP_TAGS: string[] = [];
 
 export type CanonPromise = {

--- a/tests/equivalence/workloads.ts
+++ b/tests/equivalence/workloads.ts
@@ -205,6 +205,6 @@ export const humanInTheLoop: MatchedWorkload = {
   gen: { dpc: dpcGen },
   async: { dpc: dpcAsync },
   drive: async (api) => {
-    await api.resolvePromise("dpc.0", "signal");
+    await api.resolvePromise("dpc:0", "signal");
   },
 };

--- a/tests/network/nats.test.ts
+++ b/tests/network/nats.test.ts
@@ -196,7 +196,7 @@ describe("NatsNetwork.send()", () => {
     await net.init();
 
     // origin is the lineage root: substring before the first dot of the id.
-    await net.send(promiseGetReq("foo.bar.baz", "c1"));
+    await net.send(promiseGetReq("foo:bar.baz", "c1"));
 
     const token = Buffer.from("foo", "utf8").toString("base64url");
     const reqPublish = fake.published.find((p) => p.subject.startsWith("resonate.requests."));
@@ -230,7 +230,7 @@ describe("NatsNetwork.send()", () => {
         action: {
           kind: "promise.create",
           head: { corrId: "c1", version: VERSION },
-          data: { id: "root.child.1", timeoutAt: 1, param: {}, tags: {} },
+          data: { id: "root:child.1", timeoutAt: 1, param: {}, tags: {} },
         },
       },
     };

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -104,7 +104,6 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo.1")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -112,7 +111,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -120,7 +118,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1:0.0",
       "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
@@ -150,7 +147,6 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "global",
@@ -158,7 +154,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo:0",
       "resonate:parent": "foo",
       "resonate:scope": "global",
@@ -166,7 +161,6 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo:0.0",
       "resonate:parent": "foo:0",
       "resonate:scope": "global",
@@ -194,7 +188,6 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo.1")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
@@ -202,14 +195,12 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
     expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
@@ -235,7 +226,6 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "global",
@@ -243,14 +233,12 @@ describe("Resonate usage tests", () => {
     });
     expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "local",
     });
     expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo:0",
       "resonate:scope": "local",
@@ -527,7 +515,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "f",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
     });
     await resonate.stop();
   });
@@ -552,7 +539,6 @@ describe("Resonate usage tests", () => {
     expect((await resonate.promises.get("f:0")).tags).toEqual({
       "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -577,7 +563,6 @@ describe("Resonate usage tests", () => {
     expect((await resonate.promises.get("f:0")).tags).toEqual({
       "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -604,7 +589,6 @@ describe("Resonate usage tests", () => {
     expect(durable.tags).toEqual({
       "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -631,7 +615,6 @@ describe("Resonate usage tests", () => {
       "resonate:timer": "true",
       "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -771,7 +754,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "local://any@default",
     });
     await resonate.stop();
@@ -797,7 +779,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "local://any@remoteTarget",
     });
     await resonate.stop();
@@ -823,7 +804,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "http://faasurl.com",
     });
     await resonate.stop();
@@ -849,7 +829,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "http://faasurl.com",
     });
     await resonate.stop();
@@ -875,7 +854,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "local://any@default",
     });
     await resonate.stop();
@@ -901,7 +879,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "local://any@anotherNode",
     });
     await resonate.stop();
@@ -1056,41 +1033,6 @@ describe("Resonate usage tests", () => {
     await resonate.stop();
   });
 
-  test("Using prefix at Resonate class prefixes all the promises", async () => {
-    const prefix = "myPrefix";
-    const resonate = new Resonate({ prefix });
-
-    function qux(ctx: Context) {
-      expect(ctx.id.startsWith(prefix));
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "qux";
-    }
-
-    function* baz(ctx: Context) {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      yield* ctx.run(qux);
-      return "baz";
-    }
-
-    function* bar(ctx: Context) {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "bar";
-    }
-
-    function* foo(ctx: Context) {
-      const p = yield* ctx.beginRun(bar);
-      yield* ctx.run(baz);
-      yield* ctx.run(qux);
-      yield* p;
-      return "ok";
-    }
-    const f = resonate.register("foo", foo);
-    await f.run("fooId");
-
-    await resonate.stop();
-  });
 });
 
 describe("Context usage tests", () => {

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -1032,7 +1032,6 @@ describe("Resonate usage tests", () => {
 
     await resonate.stop();
   });
-
 });
 
 describe("Context usage tests", () => {

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -85,15 +85,15 @@ describe("Resonate usage tests", () => {
     function* bar(ctx: Context): Generator {
       // origin: foo.1
       // parent: foo.1
-      // branch: foo.1.0
+      // branch: foo.1:0
       const v = yield ctx.rpc(baz);
       return v;
     }
 
     async function baz(ctx: Context): Promise<string> {
       // origin: foo.1
-      // parent: foo.1.0
-      // branch: foo.1.0.0
+      // parent: foo.1:0
+      // branch: foo.1:0.0
       return "hello";
     }
 
@@ -110,19 +110,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
+      "resonate:branch": "foo.1:0",
       "resonate:parent": "foo.1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+      "resonate:branch": "foo.1:0.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -156,19 +156,19 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
-      "resonate:branch": "foo.0",
+      "resonate:branch": "foo:0",
       "resonate:parent": "foo",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
-      "resonate:branch": "foo.0.0",
-      "resonate:parent": "foo.0",
+      "resonate:branch": "foo:0.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -200,18 +200,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
       "resonate:parent": "foo.1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo.1:0.0")).tags).toEqual({
       "resonate:origin": "foo.1",
       "resonate:prefix": "foo.1",
       "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+      "resonate:parent": "foo.1:0",
       "resonate:scope": "local",
     });
   });
@@ -241,18 +241,18 @@ describe("Resonate usage tests", () => {
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
       "resonate:prefix": "foo",
       "resonate:branch": "foo",
-      "resonate:parent": "foo.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "local",
     });
   });
@@ -454,14 +454,14 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
     await resonate.stop();
   });
@@ -479,7 +479,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await resonate.rpc(`f${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`f${i}`);
-      const p2 = await resonate.promises.get(`f${i}.0`);
+      const p2 = await resonate.promises.get(`f${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -497,7 +497,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await resonate.rpc(`g${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`g${i}`);
-      const p2 = await resonate.promises.get(`g${i}.0`);
+      const p2 = await resonate.promises.get(`g${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -514,14 +514,14 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function");
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "f",
@@ -538,19 +538,19 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -563,19 +563,19 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe(`${ctx.id}.0`);
+      expect(fu.id).toBe(`${ctx.id}:0`);
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure myId promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -591,24 +591,24 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
@@ -624,12 +624,12 @@ describe("Resonate usage tests", () => {
     });
 
     const p = await f.beginRun("f");
-    await setTimeout(100); // Ensure f.0 promise is created
+    await setTimeout(100); // Ensure f:0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
       "resonate:prefix": "f",
       "resonate:parent": "f",
@@ -657,7 +657,7 @@ describe("Resonate usage tests", () => {
     const v = await f.run("f");
     expect(v).toBe("myValue");
 
-    const durable = await resonate.promises.get(util.detachedId("f", "f.0"));
+    const durable = await resonate.promises.get(util.detachedId("f", "f:0"));
     expect(durable).toMatchObject({ state: "pending" });
 
     await resonate.stop();
@@ -764,11 +764,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -790,11 +790,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -816,11 +816,11 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
       "resonate:prefix": "f",
@@ -1254,10 +1254,10 @@ describe("Context usage tests", () => {
       expect(ctxRetryPolicy).toEqual(retryPolicy);
 
       if (f === "rfi" || f === "rfc") {
-        const p = await resonate.promises.get(`f${i}.0`);
+        const p = await resonate.promises.get(`f${i}:0`);
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       } else if (f === "detached") {
-        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}.0`));
+        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}:0`));
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       }
     }

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -84,7 +84,7 @@ async function buildComputation(
     registry,
     new TestHeartbeat(),
     new Map(),
-    new OptionsBuilder({ match: (target: string) => target, idPrefix: "test-" }),
+    new OptionsBuilder({ match: (target: string) => target }),
     logger,
   );
 

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -452,7 +452,7 @@ describe("Trace", () => {
       const { computation, effects } = await buildComputation(registry);
 
       // Pre-settle the child promise
-      await presettle(effects, "foo.1.0", 42);
+      await presettle(effects, "foo.1:0", 42);
 
       const rootPromise = createRootPromise("foo.1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -181,39 +181,39 @@ describe("base64 encoder", () => {
 
 describe("detachedId", () => {
   test("returns prefix dot-d plus cyrb53 hex of seqid", () => {
-    const result = detachedId("root", "root.0");
-    expect(result).toBe(detachedId("root", "root.0"));
-    expect(result.startsWith("root.d")).toBe(true);
+    const result = detachedId("root", "root:0");
+    expect(result).toBe(detachedId("root", "root:0"));
+    expect(result.startsWith("root:d")).toBe(true);
   });
 
   test("segment after the prefix is a `d` marker followed by hex", () => {
-    const result = detachedId("origin", "origin.3");
-    const segment = result.split(".").slice(1).join(".");
+    const result = detachedId("origin", "origin:3");
+    const segment = result.split(":").slice(1).join(":");
     expect(segment[0]).toBe("d");
     expect(segment.slice(1)).toMatch(/^[0-9a-f]+$/);
   });
 
   test("is deterministic — same inputs produce same output", () => {
-    expect(detachedId("a", "a.0")).toBe(detachedId("a", "a.0"));
+    expect(detachedId("a", "a:0")).toBe(detachedId("a", "a:0"));
   });
 
   test("different seqids produce different ids", () => {
-    expect(detachedId("root", "root.0")).not.toBe(detachedId("root", "root.1"));
+    expect(detachedId("root", "root:0")).not.toBe(detachedId("root", "root:1"));
   });
 
   test("different prefixes produce different ids", () => {
-    expect(detachedId("root.0", "root.0.0")).not.toBe(detachedId("root.1", "root.0.0"));
+    expect(detachedId("root:0", "root:0.0")).not.toBe(detachedId("root:1", "root:0.0"));
   });
 
   test("prefix is preserved before the `.d` segment", () => {
     const prefix = "my-workflow-abc123";
-    const result = detachedId(prefix, "my-workflow-abc123.5");
-    expect(result.startsWith(`${prefix}.d`)).toBe(true);
+    const result = detachedId(prefix, "my-workflow-abc123:5");
+    expect(result.startsWith(`${prefix}:d`)).toBe(true);
   });
 
   test("works with empty strings", () => {
     const result = detachedId("", "");
-    expect(result.startsWith(".d")).toBe(true);
+    expect(result.startsWith(":d")).toBe(true);
   });
 });
 

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -13,7 +13,7 @@ function makeCtx({
   timeout = Number.MAX_SAFE_INTEGER,
 } = {}) {
   const registry = new Registry();
-  const optsBuilder = new OptionsBuilder({ match: (t) => t, idPrefix: "" });
+  const optsBuilder = new OptionsBuilder({ match: (t) => t });
   return new InnerContext({
     id: "test",
     func: "testFunc",


### PR DESCRIPTION
## New promise id format

Promise ids now use the form `<promiseId>:<lineage>`:

- The root promiseId is separated from its lineage by a colon `:` (`foo` → `foo:1`); deeper lineage segments stay dot-separated (`foo:1.1`).
- **The id-prefix feature is removed:** no `prefix` constructor option, no `RESONATE_PREFIX` (including the `@resonatehq/aws`, `@resonatehq/gcp`, `@resonatehq/cloudflare` packages), no `idPrefix`/`prefixId`, no `OptionsBuilder.idPrefix`, and the SDK no longer emits the `resonate:prefix` tag. Root ids are used raw; detached ids root on the lineage origin.

Only `resonate:origin` / `resonate:branch` / `resonate:parent` are emitted now, consistent across all Resonate SDKs.

### Verification
- `npm run build` (tsc) — ok; deployment packages type-check
- `npm test` (jest) — 429 passed, 1 skipped, 26 suites