### PR TITLE
Enforce promise id format origin:lineage, remove RESONATE_PREFIX

### DIFF
--- a/examples/async/human-in-the-loop.ts
+++ b/examples/async/human-in-the-loop.ts
@@ -67,7 +67,7 @@ async function cancelOrder(_info: Info, orderId: string, note: string): Promise<
 // -- Orchestrator ---------------------------------------------------------
 
 async function fulfillOrder(ctx: Context, orderId: string, amount: number): Promise<string> {
-  // Open the human-decision promise first. Its `.id` (`{workflowId}.0`) is
+  // Open the human-decision promise first. Its `.id` (`{workflowId}:0`) is
   // available synchronously -- the address to resolve.
   const approval = ctx.promise<Decision>();
   await ctx.run(notifyReviewer, orderId, amount, approval.id);

--- a/examples/async/structured-concurrency.ts
+++ b/examples/async/structured-concurrency.ts
@@ -13,8 +13,8 @@
 // spawned is still in flight. Before foo's promise resolves, the runtime joins
 // both children.
 //
-// We prove it durably. Children get deterministic ids `{foo_id}.0` and
-// `{foo_id}.1`. After foo returns 5 we attach to those two promises by id and
+// We prove it durably. Children get deterministic ids `{foo_id}:0` and
+// `{foo_id}:1`. After foo returns 5 we attach to those two promises by id and
 // assert each resolved -- evidence the never-awaited work was awaited *by the
 // runtime* on our behalf.
 //
@@ -50,12 +50,14 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order below the workflow's origin -- a bare
+  // root joins its first lineage segment with ':' (deeper ones with '.'), so
+  // foo's children are `{foo_id}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/examples/generator/human-in-the-loop.ts
+++ b/examples/generator/human-in-the-loop.ts
@@ -71,7 +71,7 @@ async function cancelOrder(_ctx: Context, orderId: string, note: string): Promis
 
 function* fulfillOrder(ctx: Context, orderId: string, amount: number): Generator<any, string, any> {
   // Open the human-decision promise first so its id is deterministic
-  // (`{workflowId}.0`). The Future's `.id` is the address to resolve.
+  // (`{workflowId}:0`). The Future's `.id` is the address to resolve.
   const approval = yield* ctx.promise<Decision>();
   const approvalId = approval.id;
 

--- a/examples/generator/structured-concurrency.ts
+++ b/examples/generator/structured-concurrency.ts
@@ -12,7 +12,7 @@
 // flight. Before foo's promise resolves, the runtime joins both children.
 //
 // We prove it durably. `ctx.beginRun` children get deterministic ids
-// `{foo_id}.0` and `{foo_id}.1`. After foo returns 5 we attach to those two
+// `{foo_id}:0` and `{foo_id}:1`. After foo returns 5 we attach to those two
 // promises by id and assert each resolved -- evidence the never-awaited work
 // was awaited *by the runtime* on our behalf.
 //
@@ -48,12 +48,14 @@ try {
   console.log(`[foo] OK: returned ${out} (never awaited its two children)`);
 
   // The runtime awaited the two never-awaited children before resolving foo.
-  // Child ids are assigned in call order as `{parent}.{seq}` (seq from 0).
+  // Child ids are assigned in call order below the workflow's origin -- a bare
+  // root joins its first lineage segment with ':' (deeper ones with '.'), so
+  // foo's children are `{foo_id}:{seq}` (seq from 0).
   for (const [seq, n] of [
     [0, 1],
     [1, 2],
   ]) {
-    const childId = `${fooId}.${seq}`;
+    const childId = `${fooId}:${seq}`;
     const child = await resonate.get(childId);
     const childOut = await child.result();
     if (childOut !== n * 10) throw new Error(`child ${childId} resolved ${childOut}, expected ${n * 10}`);

--- a/packages/aws/src/index.ts
+++ b/packages/aws/src/index.ts
@@ -28,7 +28,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string;
   private dependencies: Map<string, any>;
@@ -54,8 +53,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     pid = undefined,
@@ -66,7 +63,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -76,11 +72,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    const resolvedPrefix = prefix ?? process.env.RESONATE_PREFIX;
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid ?? crypto.randomUUID().replace(/-/g, "");
@@ -204,7 +197,6 @@ export class Resonate {
               if (isUrl(target)) return target;
               return functionUrl;
             },
-            idPrefix: this.idPrefix,
           }),
           logger: this.logger,
         });

--- a/packages/cloudflare/src/index.ts
+++ b/packages/cloudflare/src/index.ts
@@ -28,7 +28,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string | undefined;
   private dependencies: Map<string, any>;
@@ -55,7 +54,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs.
    */
   constructor({
     pid = undefined,
@@ -66,7 +64,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -76,10 +73,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    this.idPrefix = prefix ? `${prefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid;
@@ -188,7 +183,6 @@ export class Resonate {
                 if (isUrl(target)) return target;
                 return functionUrl;
               },
-              idPrefix: this.idPrefix,
             }),
             logger: this.logger,
           });

--- a/packages/gcp/src/index.ts
+++ b/packages/gcp/src/index.ts
@@ -31,7 +31,6 @@ function isUrl(str: string): boolean {
 export class Resonate {
   private registry: Registry;
   private codec: Codec;
-  private idPrefix: string;
   private logger: Logger;
   private pid: string;
   private dependencies: Map<string, any>;
@@ -61,8 +60,6 @@ export class Resonate {
    * @param options.logLevel - Log level for the default ConsoleLogger. Defaults to `"warn"`. Takes precedence over `verbose`.
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     pid = undefined,
@@ -73,7 +70,6 @@ export class Resonate {
     logLevel = undefined,
     logger = undefined,
     encryptor = undefined,
-    prefix = undefined,
   }: {
     pid?: string;
     ttl?: number;
@@ -83,11 +79,8 @@ export class Resonate {
     logLevel?: LogLevel;
     logger?: Logger;
     encryptor?: Encryptor;
-    prefix?: string;
   } = {}) {
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-    const resolvedPrefix = prefix ?? process.env.RESONATE_PREFIX;
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
     this.pid = pid ?? crypto.randomUUID().replace(/-/g, "");
@@ -196,7 +189,6 @@ export class Resonate {
               if (isUrl(target)) return target;
               return `${proto}://${host}${req.originalUrl || ""}`;
             },
-            idPrefix: this.idPrefix,
           }),
           logger: this.logger,
         });

--- a/sim/src/worker.ts
+++ b/sim/src/worker.ts
@@ -211,7 +211,7 @@ export class WorkerProcess extends Process {
       registry,
       heartbeat: new NoopHeartbeat(),
       dependencies: new Map(),
-      optsBuilder: new OptionsBuilder({ match: (target: string) => `sim://any@${target}`, idPrefix: "" }),
+      optsBuilder: new OptionsBuilder({ match: (target: string) => `sim://any@${target}` }),
       logger,
     });
     this.network.recv((msg) => {

--- a/src/async/context.ts
+++ b/src/async/context.ts
@@ -1,5 +1,6 @@
 import type { Clock } from "../clock.js";
 import exceptions, { type ResonateError } from "../exceptions.js";
+import { joinId } from "../ids.js";
 import type { PromiseCreateReq, PromiseRecord } from "../network/types.js";
 import type { Options, OptionsBuilder } from "../options.js";
 import { delay, randomUUID } from "../platform.js";
@@ -30,11 +31,12 @@ export type Return<F> = F extends (...args: any[]) => infer R ? Awaited<R> : nev
 export interface Info {
   readonly id: string;
   readonly parentId: string;
+  /** The lineage origin: everything before the first `:` of every id in this
+   * workflow, set at the top (resonate.run/rpc) and carried through the
+   * resonate:origin tag unchanged forever — including into detached children,
+   * which mint `${originId}:d${hash}` off it. Also the anchor every descendant
+   * id extends, so it doubles as the id-generation root. */
   readonly originId: string;
-  /** The id-generation prefix (resonate:prefix). Set once at the top and
-   * propagated down unchanged — through every child AND across detached
-   * re-roots — so recursive detached ids stay bounded. */
-  readonly prefixId: string;
   readonly branchId: string;
   readonly timeoutAt: number;
   readonly attempt: number;
@@ -166,7 +168,6 @@ export class DurablePromise<T> implements Promise<T> {
 interface AsyncContextConfig {
   id: string;
   oId?: string;
-  prId?: string;
   bId?: string;
   pId?: string;
   func: string;
@@ -182,7 +183,6 @@ interface AsyncContextConfig {
 export class AsyncContext implements Context {
   readonly id: string;
   readonly originId: string;
-  readonly prefixId: string;
   readonly branchId: string;
   readonly parentId: string;
   readonly func: string;
@@ -219,7 +219,6 @@ export class AsyncContext implements Context {
   constructor(cfg: AsyncContextConfig, effects: Effects, trace: TraceCollector) {
     this.id = cfg.id;
     this.originId = cfg.oId ?? cfg.id;
-    this.prefixId = cfg.prId ?? cfg.id;
     this.branchId = cfg.bId ?? cfg.id;
     this.parentId = cfg.pId ?? cfg.id;
     this.func = cfg.func;
@@ -278,7 +277,6 @@ export class AsyncContext implements Context {
       {
         id: cfg.id,
         oId: this.originId,
-        prId: this.prefixId,
         bId: this.branchId,
         pId: this.id,
         func: cfg.func,
@@ -468,16 +466,17 @@ export class AsyncContext implements Context {
     }
 
     const idChanged = opts.id !== undefined;
-    // Detached ids are minted off the fixed id-generation prefix (NOT the grown
-    // id or the diverging origin), so recursive detached stays bounded at one
-    // segment past the prefix. Mirrors the generator engine (src/context.ts).
-    const id = idChanged ? (opts.id as string) : util.detachedId(this.prefixId, this.seqid());
+    // Detached ids are minted off the lineage origin (`${origin}:d${hash}`,
+    // one segment past it), so recursive detached stays bounded instead of
+    // growing a segment per level. Mirrors the generator engine
+    // (src/context.ts).
+    const id = idChanged ? (opts.id as string) : util.detachedId(this.originId, this.seqid());
     this.seq++;
 
     const func = registered ? registered.name : (funcOrName as string);
     const version = registered ? registered.version : opts.version || 1;
     const data = { func, args: argu, retry: opts.retryPolicy?.encode(), version };
-    const createReq = this.detachedCreateReq({ id, data, opts });
+    const createReq = this.detachedCreateReq({ id, data, opts, breaksLineage: idChanged });
     const slot = this.claimCreateSlot();
 
     // Fire-and-forget: the parent waits only for the durable CREATE to land
@@ -655,12 +654,12 @@ export class AsyncContext implements Context {
       data,
       tags: {
         "resonate:scope": "local",
-        "resonate:branch": this.branchId,
-        "resonate:parent": this.id,
+        // An explicit-id child (breaksLineage) starts a fresh self-anchored
+        // lineage: the server requires an id to extend its declared branch /
+        // parent / origin, which only the id itself satisfies.
+        "resonate:branch": breaksLineage ? id : this.branchId,
+        "resonate:parent": breaksLineage ? id : this.id,
         "resonate:origin": breaksLineage ? id : this.originId,
-        // Prefix is set at the top and propagates down unchanged forever,
-        // independent of origin (which detached/explicit-id may break).
-        "resonate:prefix": this.prefixId,
         ...opts.tags,
       },
     });
@@ -685,19 +684,34 @@ export class AsyncContext implements Context {
         "resonate:scope": "global",
         "resonate:target": opts.target,
         "resonate:branch": id,
-        "resonate:parent": this.id,
+        "resonate:parent": breaksLineage ? id : this.id,
         "resonate:origin": breaksLineage ? id : this.originId,
-        // Prefix is set at the top and propagates down unchanged forever,
-        // independent of origin (which detached/explicit-id may break).
-        "resonate:prefix": this.prefixId,
         ...opts.tags,
       },
     });
   }
 
-  // Detached: a globally-scoped promise with its own origin (lineage break) and
-  // an independent lifetime — its timeout is NOT clamped to the parent's.
-  private detachedCreateReq({ id, data, opts }: { id: string; data: any; opts: Options }): PromiseCreateReq {
+  // Detached: a globally-scoped promise with an independent lifetime — its
+  // timeout is NOT clamped to the parent's. The child keeps the *parent's*
+  // origin rather than re-rooting onto its own id: the server derives the
+  // origin as everything before the first `:` and requires every id in a
+  // lineage to start with `{origin}:`. Its id hangs off the origin
+  // (`${origin}:d${hash}`, bounding recursion), so the origin is also the
+  // resonate:parent it declares — a parent of the spawning context would be
+  // rejected. resonate:branch stays the child's own id: a detached child
+  // roots its own branch. An explicit opts.id still starts a fresh
+  // self-anchored lineage (breaksLineage).
+  private detachedCreateReq({
+    id,
+    data,
+    opts,
+    breaksLineage,
+  }: {
+    id: string;
+    data: any;
+    opts: Options;
+    breaksLineage: boolean;
+  }): PromiseCreateReq {
     return this.createReq({
       id,
       timeoutAt: this.clock.now() + opts.timeout,
@@ -706,11 +720,8 @@ export class AsyncContext implements Context {
         "resonate:scope": "global",
         "resonate:target": opts.target,
         "resonate:branch": id,
-        "resonate:parent": this.id,
-        "resonate:origin": id,
-        // Prefix carries forward unchanged across the detached re-root (origin
-        // breaks, prefix does not) — this is what keeps recursive ids bounded.
-        "resonate:prefix": this.prefixId,
+        "resonate:parent": breaksLineage ? id : this.originId,
+        "resonate:origin": breaksLineage ? id : this.originId,
         ...opts.tags,
       },
     });
@@ -737,32 +748,40 @@ export class AsyncContext implements Context {
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": this.originId,
-        // Prefix is set at the top and propagates down unchanged forever.
-        "resonate:prefix": this.prefixId,
         ...tags,
       },
     });
   }
 
   private sleepCreateReq({ id, time }: { id: string; time: number }): PromiseCreateReq {
+    // The timer is the promise's own deadline: resonate:timer makes the server
+    // settle it RESOLVED (rather than timed out) when the deadline arrives,
+    // which fires the callbacks every sleeper is suspended on. The
+    // resonate:target is what makes that deadline *happen*: the server only
+    // schedules timeouts for promises carrying an address, so a target-less
+    // timer would simply never fire. The flip side is that a target also
+    // spawns a task, dispatched immediately rather than at the wake; a timer
+    // names no function to run, so the worker that receives it drops it and
+    // lets the deadline do the waking (see AsyncCore.executeUntilBlocked).
     return this.createReq({
       id,
       timeoutAt: Math.min(time, this.timeoutAt),
       data: "",
       tags: {
         "resonate:scope": "global",
+        "resonate:target": this.options().target,
         "resonate:branch": id,
         "resonate:parent": this.id,
         "resonate:origin": this.originId,
-        // Prefix is set at the top and propagates down unchanged forever.
-        "resonate:prefix": this.prefixId,
         "resonate:timer": "true",
       },
     });
   }
 
   private seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // A bare root joins its first lineage segment with ':', deeper segments
+    // join with '.' -- see ids.joinId.
+    return joinId(this.id, `${this.seq}`);
   }
 }
 

--- a/src/async/core.ts
+++ b/src/async/core.ts
@@ -2,6 +2,7 @@ import type { Clock } from "../clock.js";
 import type { Codec } from "../codec.js";
 import exceptions, { ResonateError } from "../exceptions.js";
 import type { Heartbeat } from "../heartbeat.js";
+import { originOf } from "../ids.js";
 import type { Logger } from "../logger.js";
 import { isRedirect, isSuccess, type Message, type PromiseRecord, type TaskRecord } from "../network/types.js";
 import type { OptionsBuilder } from "../options.js";
@@ -101,6 +102,42 @@ export class Core {
     preload?: PromiseRecord[],
   ): Promise<Status> {
     util.assert(task.state === "acquired", `expected task state to be 'acquired', got '${task.state}'`);
+
+    // A resonate:timer promise is a durable sleep. It names no function to
+    // run; it only carries a task at all because the target that gets the
+    // server to *schedule* its deadline also spawns one.
+    if (rootPromise.tags["resonate:timer"] === "true") {
+      const collector = new TraceCollector();
+      if (rootPromise.state === "pending") {
+        // Not yet due: drop the task and let the deadline settle the promise,
+        // which is what wakes the sleepers. Dropping means exactly that: no
+        // fulfill (that would end the sleep early), no suspend (a task cannot
+        // await its own promise), and no release (the server re-dispatches a
+        // released task immediately, which would spin). The lease simply
+        // lapses; a re-delivery before the wake is dropped again, and one
+        // after it takes the settled branch below.
+        this.logger.debug(
+          { component: "async-core", taskId: task.id, timeoutAt: rootPromise.timeoutAt },
+          "dropping not-yet-due timer task",
+        );
+        return { kind: "suspended", awaited: [], trace: collector.getTrace() };
+      }
+      // Settled: a durable sleep whose wake has passed. It carries no
+      // function/args, so it cannot go through the run driver; fulfill the
+      // task with the promise's settlement. (The server normally fulfills a
+      // timer's task itself when the deadline settles the promise, so this
+      // only catches a delivery already in flight at that moment.)
+      const status: Done = {
+        kind: "done",
+        id: rootPromise.id,
+        state: rootPromise.state === "resolved" ? "resolved" : "rejected",
+        value: rootPromise.value?.data,
+        trace: collector.getTrace(),
+      };
+      await this.fulfillTask(task, rootPromise, status);
+      return status;
+    }
+
     const effects = util.buildEffects(this.send, this.codec, { id: task.id, version: task.version }, preload);
 
     try {
@@ -182,12 +219,13 @@ export class Core {
         new AsyncContext(
           {
             id: rootPromise.id,
-            oId: rootPromise.tags["resonate:origin"] ?? rootPromise.id,
-            // The id-generation prefix, propagated unchanged across re-roots (a
-            // detached child resets origin to its own id but carries prefix
-            // forward), so recursive detached ids stay bounded. Falls back to
-            // the id like oId.
-            prId: rootPromise.tags["resonate:prefix"] ?? rootPromise.id,
+            // Take the lineage origin from the promise's resonate:origin tag,
+            // which the dispatcher set: every id in the lineage is
+            // `{origin}:{lineage}`, so this is both the ancestry root and the
+            // anchor this workflow's own child ids extend. A tag-less promise
+            // falls back to deriving it from the id the same way the server
+            // does -- which for a genuine top-level root is the id itself.
+            oId: rootPromise.tags["resonate:origin"] ?? originOf(rootPromise.id),
             func: registered.func.name,
             clock: this.clock,
             registry: this.registry,

--- a/src/async/resonate.ts
+++ b/src/async/resonate.ts
@@ -3,6 +3,7 @@ import { Codec } from "../codec.js";
 import { type Encryptor, NoopEncryptor } from "../encryptor.js";
 import exceptions, { ResonateTimeoutException } from "../exceptions.js";
 import { AsyncHeartbeat, type Heartbeat, NoopHeartbeat } from "../heartbeat.js";
+import { validateRootId } from "../ids.js";
 import { ConsoleLogger, type Logger, type LogLevel } from "../logger.js";
 import { HttpNetwork, PollMessageSource } from "../network/http.js";
 import { LocalNetwork } from "../network/local.js";
@@ -60,7 +61,6 @@ export class Resonate {
   private clock: WallClock;
   private pid: string;
   private ttl: number;
-  private idPrefix: string;
 
   private core: Core;
   private codec: Codec;
@@ -91,7 +91,6 @@ export class Resonate {
     logger = undefined,
     encryptor = undefined,
     network = undefined,
-    prefix = undefined,
   }: {
     url?: string;
     group?: string;
@@ -104,14 +103,10 @@ export class Resonate {
     logger?: Logger;
     encryptor?: Encryptor;
     network?: Network;
-    prefix?: string;
   } = {}) {
     this.clock = new WallClock();
     this.ttl = ttl;
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-
-    const resolvedPrefix = prefix ?? getEnv("RESONATE_PREFIX");
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
 
     const resolvedLogLevel: LogLevel = logLevel ?? (verbose ? "debug" : "warn");
     this.logger = logger ?? new ConsoleLogger(resolvedLogLevel);
@@ -155,7 +150,7 @@ export class Resonate {
 
     this.registry = new Registry();
     this.dependencies = new Map();
-    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network), idPrefix: this.idPrefix });
+    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network) });
 
     this.core = new Core({
       pid: this.pid,
@@ -254,7 +249,11 @@ export class Resonate {
       );
     }
 
-    id = `${this.idPrefix}${id}`;
+    // Validated at the call site that named the workflow, rather than
+    // surfacing later as an opaque 400 from the server: the id becomes the
+    // origin of its whole lineage, so the reserved separators ('.' and ':')
+    // are rejected outright.
+    validateRootId(id);
     util.assert(registered.version > 0, "function version must be greater than zero");
 
     const { promise, task } = await this.taskCreate({
@@ -275,10 +274,10 @@ export class Resonate {
             },
             tags: {
               ...opts.tags,
+              // A genuine top-level root is its own lineage origin, so
+              // origin == branch == parent == id here. Every descendant id
+              // extends it as `{id}:{lineage}`.
               "resonate:origin": id,
-              // A genuine top-level root is its own lineage origin AND its own
-              // id-generation prefix; the prefix then propagates down unchanged.
-              "resonate:prefix": id,
               "resonate:branch": id,
               "resonate:parent": id,
               "resonate:scope": "global",
@@ -318,7 +317,7 @@ export class Resonate {
       throw exceptions.REGISTRY_FUNCTION_NOT_REGISTERED(funcOrName.name, opts.version);
     }
 
-    id = `${this.idPrefix}${id}`;
+    validateRootId(id);
     const func = registered ? registered.name : (funcOrName as string);
     const version = registered ? registered.version : opts.version || 1;
 
@@ -331,10 +330,10 @@ export class Resonate {
         param: { data: { func, args, retry: opts.retryPolicy?.encode(), version }, headers: {} },
         tags: {
           ...opts.tags,
+          // A genuine top-level root is its own lineage origin, so
+          // origin == branch == parent == id here. Every descendant id
+          // extends it as `{id}:{lineage}`.
           "resonate:origin": id,
-          // A genuine top-level root is its own lineage origin AND its own
-          // id-generation prefix; the prefix then propagates down unchanged.
-          "resonate:prefix": id,
           "resonate:branch": id,
           "resonate:parent": id,
           "resonate:scope": "global",
@@ -377,7 +376,14 @@ export class Resonate {
       version: registered ? registered.version : opts.version || 1,
     });
 
-    await this.schedules.create(name, cron, `${this.idPrefix}{{.id}}.{{.timestamp}}`, opts.timeout, {
+    // Each firing creates a root promise named from this id, so the schedule
+    // name is bound by the same rules as a run/rpc id. The server stamps the
+    // *whole* templated id onto the fired promise's resonate:origin tag, so
+    // the template must join with a plain '-': a '.' would make every child
+    // of a scheduled run rejected (dot_in_origin) and a ':' would hide the
+    // timestamp below the origin, collapsing every firing onto one lineage.
+    validateRootId(name);
+    await this.schedules.create(name, cron, "{{.id}}-{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,
       promiseData: data,
       promiseTags: { ...opts.tags, "resonate:target": opts.target },
@@ -390,7 +396,8 @@ export class Resonate {
 
   /** Returns a handle to an existing durable promise by id. */
   public async get<T = any>(id: string): Promise<ResonateHandle<T>> {
-    id = `${this.idPrefix}${id}`;
+    // get is a lookup, not a create: it takes any id, including a child's
+    // (e.g. "wf:1.2"), so it deliberately does NOT validate.
     const promise = await this.promiseGet({
       kind: "promise.get",
       head: { corrId: randomUUID(), version: util.VERSION },

--- a/src/async/resonate.ts
+++ b/src/async/resonate.ts
@@ -251,8 +251,8 @@ export class Resonate {
 
     // Validated at the call site that named the workflow, rather than
     // surfacing later as an opaque 400 from the server: the id becomes the
-    // origin of its whole lineage, so the reserved separators ('.' and ':')
-    // are rejected outright.
+    // origin of its whole lineage, so ':' is rejected outright ('.' is only
+    // read below the origin).
     validateRootId(id);
     util.assert(registered.version > 0, "function version must be greater than zero");
 
@@ -379,9 +379,10 @@ export class Resonate {
     // Each firing creates a root promise named from this id, so the schedule
     // name is bound by the same rules as a run/rpc id. The server stamps the
     // *whole* templated id onto the fired promise's resonate:origin tag, so
-    // the template must join with a plain '-': a '.' would make every child
-    // of a scheduled run rejected (dot_in_origin) and a ':' would hide the
-    // timestamp below the origin, collapsing every firing onto one lineage.
+    // the template must join with a plain '-': a ':' would hide the timestamp
+    // below the origin, collapsing every firing onto one lineage. A '.' is
+    // fine now — it is only read below the origin — but '-' keeps the
+    // timestamp clearly distinct from any dots in the schedule name.
     validateRootId(name);
     await this.schedules.create(name, cron, "{{.id}}-{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,

--- a/src/computation.ts
+++ b/src/computation.ts
@@ -3,6 +3,7 @@ import { InnerContext } from "./context.js";
 import { Coroutine } from "./coroutine.js";
 import exceptions from "./exceptions.js";
 import type { Heartbeat } from "./heartbeat.js";
+import { originOf } from "./ids.js";
 import type { Logger } from "./logger.js";
 import type { PromiseRecord } from "./network/types.js";
 import type { OptionsBuilder } from "./options.js";
@@ -116,11 +117,13 @@ export class Computation {
 
     const ctxConfig = {
       id: this.id,
-      oId: rootPromise.tags["resonate:origin"] ?? this.id,
-      // The id-generation prefix, propagated unchanged across re-roots (a
-      // detached child resets origin to its own id but carries prefix forward),
-      // so recursive detached ids stay bounded. Falls back to the id like oId.
-      prId: rootPromise.tags["resonate:prefix"] ?? this.id,
+      // Take the lineage origin from the promise's resonate:origin tag, which
+      // the dispatcher set: every id in the lineage is `{origin}:{lineage}`,
+      // so this is both the ancestry root and the anchor this computation's
+      // own child ids extend. A tag-less promise falls back to deriving it
+      // from the id the same way the server does -- which for a genuine
+      // top-level root is the id itself.
+      oId: rootPromise.tags["resonate:origin"] ?? originOf(this.id),
       func: registered.func.name,
       clock: this.clock,
       registry: this.registry,

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import type { Clock } from "./clock.js";
 import exceptions, { type ResonateError } from "./exceptions.js";
+import { joinId } from "./ids.js";
 import type { PromiseCreateReq } from "./network/types.js";
 import type { Options, OptionsBuilder } from "./options.js";
 import { randomUUID } from "./platform.js";
@@ -192,7 +193,6 @@ export class Future<T> implements Iterable<Future<T>> {
 export interface Context {
   readonly id: string;
   readonly originId: string;
-  readonly prefixId: string;
   readonly parentId: string;
   readonly branchId: string;
   readonly info: { readonly attempt: number; readonly timeout: number; readonly version: number };
@@ -273,7 +273,6 @@ export class InnerContext implements Context {
   readonly nonRetryableErrors: Array<new (...args: any[]) => Error>;
 
   readonly originId: string;
-  readonly prefixId: string;
   readonly branchId: string;
   readonly parentId: string;
   readonly clock: Clock;
@@ -290,7 +289,6 @@ export class InnerContext implements Context {
   constructor({
     id,
     oId = id,
-    prId = id,
     bId = id,
     pId = id,
     func,
@@ -305,7 +303,6 @@ export class InnerContext implements Context {
   }: {
     id: string;
     oId?: string;
-    prId?: string;
     bId?: string;
     pId?: string;
     func: string;
@@ -319,14 +316,12 @@ export class InnerContext implements Context {
     nonRetryableErrors?: Array<new (...args: any[]) => Error>;
   }) {
     this.id = id;
+    // The lineage origin: everything before the first `:` of every id in this
+    // workflow, set at the top (resonate.run/rpc) and carried through the
+    // resonate:origin tag unchanged forever -- including into detached
+    // children, which mint `${originId}:d${hash}` off it. Also the anchor
+    // every descendant id extends, so it doubles as the id-generation root.
     this.originId = oId;
-    // The id-generation prefix (resonate:prefix). Set once at the top
-    // (resonate.run/rpc) and propagated down unchanged forever -- through every
-    // child AND across detached re-roots -- never tracking the (diverging)
-    // lineage origin. Bounds recursive detached ids: each level mints
-    // `${prefixId}.d${hash}` off this fixed prefix. Mirrors the Python SDK's
-    // `Context.prefix_id`.
-    this.prefixId = prId;
     this.branchId = bId;
     this.parentId = pId;
     this.func = func;
@@ -362,7 +357,6 @@ export class InnerContext implements Context {
     return new InnerContext({
       id,
       oId: this.originId,
-      prId: this.prefixId,
       bId: this.branchId,
       pId: this.id,
       func,
@@ -573,7 +567,7 @@ export class InnerContext implements Context {
 
     const idChanged = opts.id !== undefined;
 
-    const id = idChanged ? opts.id : util.detachedId(this.prefixId, this.seqid());
+    const id = idChanged ? opts.id : util.detachedId(this.originId, this.seqid());
     this.seq++;
 
     const func = registered ? registered.name : (funcOrName as string);
@@ -590,16 +584,23 @@ export class InnerContext implements Context {
       id,
       func,
       version,
-      // detached ALWAYS breaks the origin lineage (breaksLineage: true): it is
-      // fire-and-forget and runs as its own root, so resonate:origin must equal
-      // its own id (origin == id == branch), starting a fresh lineage. Recursive
-      // detached ids stay bounded NOT via origin but via resonate:prefix, which
-      // is propagated down unchanged (set in remoteCreateReq = this.prefixId) and
-      // is what `util.detachedId(this.prefixId, ...)` roots the id on. So each
-      // level mints `${prefix}.d${hash}` off the same fixed prefix instead of
-      // off its own grown id. Mirrors the Python SDK (detached origin = its id,
-      // prefix carried forward).
-      this.remoteCreateReq({ id, data, opts, maxTimeout: Number.MAX_SAFE_INTEGER, breaksLineage: true }),
+      // A detached child keeps the *parent's* origin rather than re-rooting
+      // onto its own id: the server derives the origin as everything before
+      // the first `:` and requires every id in a lineage to start with
+      // `{origin}:`. Its id hangs off the origin (`${origin}:d${hash}`, one
+      // segment past it, bounding recursion), so the origin is also the
+      // resonate:parent it declares -- a parent of the spawning context would
+      // be rejected. resonate:branch stays the child's own id: a detached
+      // child roots its own branch. An explicit opts.id still starts a fresh
+      // self-anchored lineage (breaksLineage).
+      this.remoteCreateReq({
+        id,
+        data,
+        opts,
+        maxTimeout: Number.MAX_SAFE_INTEGER,
+        breaksLineage: idChanged,
+        parent: idChanged ? id : this.originId,
+      }),
       "detached",
     );
   }
@@ -680,12 +681,12 @@ export class InnerContext implements Context {
         param: { headers: {}, data },
         tags: {
           "resonate:scope": "local",
-          "resonate:branch": this.branchId,
-          "resonate:parent": this.id,
+          // An explicit-id child (breaksLineage) starts a fresh self-anchored
+          // lineage: the server requires an id to extend its declared branch /
+          // parent / origin, which only the id itself satisfies.
+          "resonate:branch": breaksLineage ? id : this.branchId,
+          "resonate:parent": breaksLineage ? id : this.id,
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...opts.tags,
         },
       },
@@ -697,12 +698,17 @@ export class InnerContext implements Context {
     data,
     opts,
     breaksLineage,
+    parent,
     maxTimeout = this.info.timeout,
   }: {
     id: string;
     data: any;
     opts: Options;
     breaksLineage: boolean;
+    // Only detached overrides the parent: its id is minted off the origin
+    // rather than off the spawning context, and the server requires every id
+    // to extend its declared resonate:parent.
+    parent?: string;
     maxTimeout?: number;
   }): PromiseCreateReq {
     // timeout cannot be greater than parent timeout (unless detached)
@@ -718,11 +724,8 @@ export class InnerContext implements Context {
           "resonate:scope": "global",
           "resonate:target": opts.target,
           "resonate:branch": id,
-          "resonate:parent": this.id,
+          "resonate:parent": parent ?? (breaksLineage ? id : this.id),
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...opts.tags,
         },
         param: { headers: {}, data },
@@ -756,11 +759,8 @@ export class InnerContext implements Context {
         tags: {
           "resonate:scope": "global",
           "resonate:branch": id,
-          "resonate:parent": this.id,
+          "resonate:parent": breaksLineage ? id : this.id,
           "resonate:origin": breaksLineage ? id : this.originId,
-          // Prefix is set at the top and propagates down unchanged forever,
-          // independent of origin (which detached/explicit-id may break).
-          "resonate:prefix": this.prefixId,
           ...tags,
         },
       },
@@ -768,13 +768,21 @@ export class InnerContext implements Context {
   }
 
   sleepCreateOpts({ id, time }: { id: string; time: number }): PromiseCreateReq {
+    // The timer is the promise's own deadline: resonate:timer makes the server
+    // settle it RESOLVED (rather than timed out) when the deadline arrives,
+    // which fires the callbacks every sleeper is suspended on. The
+    // resonate:target is what makes that deadline *happen*: the server only
+    // schedules timeouts for promises carrying an address, so a target-less
+    // timer would simply never fire. The flip side is that a target also
+    // spawns a task, dispatched immediately rather than at the wake; a timer
+    // names no function to run, so the worker that receives it drops it and
+    // lets the deadline do the waking (see Core.executeUntilBlocked).
     const tags = {
       "resonate:scope": "global",
+      "resonate:target": this.options().target,
       "resonate:branch": id,
       "resonate:parent": this.id,
       "resonate:origin": this.originId,
-      // Prefix is set at the top and propagates down unchanged forever.
-      "resonate:prefix": this.prefixId,
       "resonate:timer": "true",
     };
 
@@ -794,6 +802,8 @@ export class InnerContext implements Context {
   }
 
   seqid(): string {
-    return `${this.id}.${this.seq}`;
+    // A bare root joins its first lineage segment with ':', deeper segments
+    // join with '.' -- see ids.joinId.
+    return joinId(this.id, `${this.seq}`);
   }
 }

--- a/src/core.ts
+++ b/src/core.ts
@@ -9,6 +9,7 @@ import type { OptionsBuilder } from "./options.js";
 import { randomUUID } from "./platform.js";
 import type { Registry } from "./registry.js";
 import { Constant, Exponential, Linear, Never, type RetryPolicyConstructor } from "./retries.js";
+import { TraceCollector } from "./trace.js";
 import type { Effects, Send } from "./types.js";
 import * as util from "./util.js";
 
@@ -79,6 +80,42 @@ export class Core {
     preload?: PromiseRecord[],
   ): Promise<Status> {
     util.assert(task.state === "acquired", `expected task state to be 'acquired', got '${task.state}'`);
+
+    // A resonate:timer promise is a durable sleep. It names no function to
+    // run; it only carries a task at all because the target that gets the
+    // server to *schedule* its deadline also spawns one.
+    if (rootPromise.tags["resonate:timer"] === "true") {
+      const collector = new TraceCollector();
+      if (rootPromise.state === "pending") {
+        // Not yet due: drop the task and let the deadline settle the promise,
+        // which is what wakes the sleepers. Dropping means exactly that: no
+        // fulfill (that would end the sleep early), no suspend (a task cannot
+        // await its own promise), and no release (the server re-dispatches a
+        // released task immediately, which would spin). The lease simply
+        // lapses; a re-delivery before the wake is dropped again, and one
+        // after it takes the settled branch below.
+        this.logger.debug(
+          { component: "core", taskId: task.id, timeoutAt: rootPromise.timeoutAt },
+          "dropping not-yet-due timer task",
+        );
+        return { kind: "suspended", awaited: [], trace: collector.getTrace() };
+      }
+      // Settled: a durable sleep whose wake has passed. It carries no
+      // function/args, so it cannot go through the computation; fulfill the
+      // task with the promise's settlement. (The server normally fulfills a
+      // timer's task itself when the deadline settles the promise, so this
+      // only catches a delivery already in flight at that moment.)
+      const status: Done = {
+        kind: "done",
+        id: rootPromise.id,
+        state: rootPromise.state === "resolved" ? "resolved" : "rejected",
+        value: rootPromise.value?.data,
+        trace: collector.getTrace(),
+      };
+      await this.fulfillTask(task, rootPromise, status);
+      return status;
+    }
+
     const computation = this.createComputation(
       rootPromise.id,
       util.buildEffects(this.send, this.codec, { id: task.id, version: task.version }, preload),

--- a/src/exceptions.ts
+++ b/src/exceptions.ts
@@ -108,6 +108,11 @@ export default {
       cause: c,
     });
   },
+  INVALID_ID: (id: string, reason: string) => {
+    // A caller-supplied root id the server's id format cannot carry — see
+    // `ids.validateRootId`.
+    return new ResonateError("10", "InvalidId", `Invalid id '${id}': ${reason}`);
+  },
   PANIC: (src: string, msg: string | undefined) => {
     src = src.charAt(0).toUpperCase() + src.slice(1);
     msg = msg ? `: ${msg}` : "";

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -1,0 +1,88 @@
+// The promise id format, in one place.
+//
+// The server treats a promise id as `<origin>:<lineage>`: the **origin** is
+// everything before the first `:`, and the lineage segments below it are
+// `.`-separated:
+//
+//   root -> root:1 -> root:1.1 -> root:1.1.1
+//
+// The origin is load-bearing. `promise.register_callback` and `task.suspend`
+// require an awaiter and its awaited promise to share one, it selects the
+// origin-state partition a request is routed to, and `promise.create` rejects
+// an id that does not extend the `resonate:origin` / `resonate:branch` /
+// `resonate:parent` it declares. So the SDK mints ids with `joinId` and reads
+// them back with `originOf`, both of which mirror the server's own rules.
+//
+// A root id is supplied by the caller and becomes the origin of its whole
+// lineage, so `validateRootId` keeps both separators out of it, exactly as the
+// server does for the origin tag itself.
+
+import exceptions from "./exceptions.js";
+
+/** Separates the origin from the lineage below it. A bare root joins its
+ * first lineage segment with this. */
+export const ORIGIN_SEP = ":";
+
+/** Separates lineage segments below the origin. */
+export const LINEAGE_SEP = ".";
+
+/**
+ * Append a lineage `segment` to `ancestor`.
+ *
+ * A bare root joins its *first* segment with `:`; an ancestor that already
+ * carries lineage joins deeper segments with `.`, keeping the whole subtree
+ * under one origin:
+ *
+ *   joinId("root", "1")     -> "root:1"
+ *   joinId("root:1", "2")   -> "root:1.2"
+ *   joinId("root:1.2", "3") -> "root:1.2.3"
+ *
+ * This is exactly the separator rule the server's `resonate:branch` /
+ * `resonate:parent` validation applies.
+ */
+export function joinId(ancestor: string, segment: string): string {
+  const sep = ancestor.includes(ORIGIN_SEP) ? LINEAGE_SEP : ORIGIN_SEP;
+  return `${ancestor}${sep}${segment}`;
+}
+
+/**
+ * The lineage origin of `id`: everything before the first `:`.
+ *
+ * Mirrors the server's `origin()`. An id with no lineage below it (a root) is
+ * its own origin.
+ */
+export function originOf(id: string): string {
+  const sep = id.indexOf(ORIGIN_SEP);
+  return sep === -1 ? id : id.slice(0, sep);
+}
+
+/**
+ * Validate a caller-supplied root id (`run` / `rpc` / `schedule` / an explicit
+ * `options({ id })`), returning it.
+ *
+ * Both separators are **reserved**: a root becomes the origin of its whole
+ * lineage, and the server rejects an origin containing either one outright
+ * (`dot_in_origin` / `colon_in_origin`). `.` because it separates lineage
+ * segments; `:` because the origin is everything before an id's *first* `:`,
+ * so an origin holding one could never be split back out of any id.
+ *
+ * @throws {ResonateError} here, at the call site that named the workflow,
+ *   rather than surfacing later as an opaque 400 from a background create.
+ */
+export function validateRootId(id: string): string {
+  if (!id) {
+    throw exceptions.INVALID_ID(id, "id must not be empty");
+  }
+  if (id.includes("\0")) {
+    throw exceptions.INVALID_ID(id, "id must not contain null bytes");
+  }
+  for (const sep of [LINEAGE_SEP, ORIGIN_SEP]) {
+    if (id.includes(sep)) {
+      throw exceptions.INVALID_ID(
+        id,
+        `id must not contain '${sep}': it is reserved as a lineage separator in the ids the SDK mints below this one`,
+      );
+    }
+  }
+  return id;
+}

--- a/src/ids.ts
+++ b/src/ids.ts
@@ -14,8 +14,11 @@
 // them back with `originOf`, both of which mirror the server's own rules.
 //
 // A root id is supplied by the caller and becomes the origin of its whole
-// lineage, so `validateRootId` keeps both separators out of it, exactly as the
-// server does for the origin tag itself.
+// lineage, so `validateRootId` keeps `:` out of it, exactly as the server does
+// for the origin tag itself. `.` is *not* reserved there: it only separates
+// segments below the origin, and the origin is recovered by splitting on the
+// first `:`, so a dotted root (`my.app.workflow`) survives the round trip
+// intact.
 
 import exceptions from "./exceptions.js";
 
@@ -60,11 +63,16 @@ export function originOf(id: string): string {
  * Validate a caller-supplied root id (`run` / `rpc` / `schedule` / an explicit
  * `options({ id })`), returning it.
  *
- * Both separators are **reserved**: a root becomes the origin of its whole
- * lineage, and the server rejects an origin containing either one outright
- * (`dot_in_origin` / `colon_in_origin`). `.` because it separates lineage
- * segments; `:` because the origin is everything before an id's *first* `:`,
- * so an origin holding one could never be split back out of any id.
+ * Only `:` is **reserved**: a root becomes the origin of its whole lineage,
+ * and the origin is everything before an id's *first* `:`, so an origin
+ * holding one could never be split back out of any id. The server rejects it
+ * outright (`colon_in_origin`).
+ *
+ * `.` is allowed. It separates lineage segments *below* the origin, which is
+ * only ever read after the origin has been split off, so a dotted root id
+ * (`my.app.workflow`) is unambiguous:
+ *
+ *   my.app.workflow -> my.app.workflow:1 -> my.app.workflow:1.1
  *
  * @throws {ResonateError} here, at the call site that named the workflow,
  *   rather than surfacing later as an opaque 400 from a background create.
@@ -76,13 +84,11 @@ export function validateRootId(id: string): string {
   if (id.includes("\0")) {
     throw exceptions.INVALID_ID(id, "id must not contain null bytes");
   }
-  for (const sep of [LINEAGE_SEP, ORIGIN_SEP]) {
-    if (id.includes(sep)) {
-      throw exceptions.INVALID_ID(
-        id,
-        `id must not contain '${sep}': it is reserved as a lineage separator in the ids the SDK mints below this one`,
-      );
-    }
+  if (id.includes(ORIGIN_SEP)) {
+    throw exceptions.INVALID_ID(
+      id,
+      `id must not contain '${ORIGIN_SEP}': it separates the origin from the lineage in the ids the SDK mints below this one, so an id holding one could never be split back out`,
+    );
   }
   return id;
 }

--- a/src/network/local.ts
+++ b/src/network/local.ts
@@ -412,10 +412,16 @@ export class Server {
       listeners: new Set(),
     };
     changes.push(this.setPromise(promise));
-    changes.push(this.setPTimeout({ id: req.data.id, timeout: req.data.timeoutAt }));
 
     const address = req.data.tags["resonate:target"];
     if (address) {
+      // Only a promise carrying an address is expired by the tick loop. A
+      // target-less promise (a bare ctx.promise) is never timed out by the
+      // scheduler, so a durable timer has to carry a target to fire at all —
+      // see Context.sleep. Scheduling one here regardless would make this
+      // simulation *more* permissive than the server, which is invisible to
+      // every test that only asserts success.
+      changes.push(this.setPTimeout({ id: req.data.id, timeout: req.data.timeoutAt }));
       const delay = Number(req.data.tags["resonate:delay"]);
       const deferred = Number.isFinite(delay) && now < delay;
 
@@ -677,7 +683,12 @@ export class Server {
       listeners: new Set(),
     };
     changes.push(this.setPromise(promise));
-    changes.push(this.setPTimeout({ id: actionData.id, timeout: actionData.timeoutAt }));
+    // Same scheduler invariant as promise.create: only a promise carrying a
+    // target is expired by the tick loop. A task.create root always carries
+    // one in practice, but the guard keeps the invariant explicit.
+    if (actionData.tags["resonate:target"]) {
+      changes.push(this.setPTimeout({ id: actionData.id, timeout: actionData.timeoutAt }));
+    }
 
     // Step 2: Create task in acquired state
     const task: Task = {

--- a/src/network/nats.ts
+++ b/src/network/nats.ts
@@ -1,5 +1,6 @@
 import type { Msg, MsgHdrs, NatsConnection, Subscription } from "@nats-io/transport-node";
 import { ResonateTimeoutException } from "../exceptions.js";
+import { originOf } from "../ids.js";
 import type { Logger } from "../logger.js";
 import { randomUUID } from "../platform.js";
 import type { Network } from "./network.js";
@@ -32,11 +33,10 @@ const REPLY_HEADER = "Resonate-Reply-To";
 // ROUTING HELPERS
 // =============================================================================
 
-// Return the lineage origin: the substring before the first `.`.
-function idToOrigin(id: string): string {
-  const dot = id.indexOf(".");
-  return dot === -1 ? id : id.slice(0, dot);
-}
+// The lineage origin of an id — see `src/ids.ts`. Aliased here because it is
+// what selects the server's origin-state partition (below), so it must agree
+// with the server's own `origin()` for every id shape.
+const idToOrigin = originOf;
 
 // Derive the routing origin from a request, mirroring the server's client.
 //

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,3 +1,4 @@
+import { validateRootId } from "./ids.js";
 import type { RetryPolicy } from "./retries.js";
 import * as util from "./util.js";
 
@@ -5,10 +6,8 @@ export const RESONATE_OPTIONS: unique symbol = Symbol("ResonateOptions");
 
 export class OptionsBuilder {
   private match: (target: string) => string;
-  private idPrefix: string;
-  constructor({ match, idPrefix }: { match: (target: string) => string; idPrefix: string }) {
+  constructor({ match }: { match: (target: string) => string }) {
     this.match = (target: string) => (util.isUrl(target) ? target : match(target));
-    this.idPrefix = idPrefix;
   }
 
   build({
@@ -28,7 +27,9 @@ export class OptionsBuilder {
     version?: number;
     nonRetryableErrors?: Array<new (...args: any[]) => Error>;
   } = {}): Options {
-    id = id ? `${this.idPrefix}${id}` : id;
+    // An explicit id starts a fresh self-anchored lineage, so it is bound by
+    // the same rules as a run/rpc root id.
+    id = id !== undefined ? validateRootId(id) : id;
     return new Options({ id, retryPolicy, tags, target: this.match(target), timeout, version, nonRetryableErrors });
   }
 }

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -4,6 +4,7 @@ import { Core } from "./core.js";
 import { type Encryptor, NoopEncryptor } from "./encryptor.js";
 import exceptions, { ResonateTimeoutException } from "./exceptions.js";
 import { AsyncHeartbeat, type Heartbeat, NoopHeartbeat } from "./heartbeat.js";
+import { validateRootId } from "./ids.js";
 import { ConsoleLogger, type Logger, type LogLevel } from "./logger.js";
 import { HttpNetwork, PollMessageSource } from "./network/http.js";
 import { LocalNetwork } from "./network/local.js";
@@ -57,7 +58,6 @@ export class Resonate {
 
   private pid: string;
   private ttl: number;
-  private idPrefix;
 
   private core: Core;
   private codec: Codec;
@@ -94,8 +94,6 @@ export class Resonate {
    * @param options.logger - Custom logger implementation. Defaults to {@link ConsoleLogger}.
    * @param options.encryptor - Payload encryptor. Defaults to {@link NoopEncryptor}.
    * @param options.network - Custom network implementation. Defaults to `undefined`.
-   * @param options.prefix - ID prefix applied to generated IDs. Defaults to
-   *   `process.env.RESONATE_PREFIX` when set.
    */
   constructor({
     url = undefined,
@@ -109,7 +107,6 @@ export class Resonate {
     logger = undefined,
     encryptor = undefined,
     network = undefined,
-    prefix = undefined,
   }: {
     url?: string;
     group?: string;
@@ -122,14 +119,10 @@ export class Resonate {
     logger?: Logger;
     encryptor?: Encryptor;
     network?: Network;
-    prefix?: string;
   } = {}) {
     this.clock = new WallClock();
     this.ttl = ttl;
     this.codec = new Codec(encryptor ?? new NoopEncryptor());
-
-    const resolvedPrefix = prefix ?? getEnv("RESONATE_PREFIX");
-    this.idPrefix = resolvedPrefix ? `${resolvedPrefix}:` : "";
 
     // Resolve logger: explicit logger > ConsoleLogger with resolved level
     // logLevel takes precedence over verbose; verbose: true -> "debug"
@@ -182,7 +175,7 @@ export class Resonate {
     this.registry = new Registry();
     this.dependencies = new Map();
 
-    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network), idPrefix: this.idPrefix });
+    this.optsBuilder = new OptionsBuilder({ match: this.network.match.bind(this.network) });
 
     this.core = new Core({
       pid: this.pid,
@@ -310,7 +303,11 @@ export class Resonate {
       );
     }
 
-    id = `${this.idPrefix}${id}`;
+    // Validated at the call site that named the workflow, rather than
+    // surfacing later as an opaque 400 from the server: the id becomes the
+    // origin of its whole lineage, so the reserved separators ('.' and ':')
+    // are rejected outright.
+    validateRootId(id);
 
     util.assert(registered.version > 0, "function version must be greater than zero");
     const { promise, task } = await this.taskCreate({
@@ -336,10 +333,10 @@ export class Resonate {
             },
             tags: {
               ...opts.tags,
+              // A genuine top-level root is its own lineage origin, so
+              // origin == branch == parent == id here. Every descendant id
+              // extends it as `{id}:{lineage}`.
               "resonate:origin": id,
-              // A genuine top-level root is its own lineage origin AND its own
-              // id-generation prefix; the prefix then propagates down unchanged.
-              "resonate:prefix": id,
               "resonate:branch": id,
               "resonate:parent": id,
               "resonate:scope": "global",
@@ -387,7 +384,7 @@ export class Resonate {
       throw exceptions.REGISTRY_FUNCTION_NOT_REGISTERED(funcOrName.name, opts.version);
     }
 
-    id = `${this.idPrefix}${id}`;
+    validateRootId(id);
 
     const func = registered ? registered.name : (funcOrName as string);
     const version = registered ? registered.version : opts.version || 1;
@@ -408,10 +405,10 @@ export class Resonate {
         },
         tags: {
           ...opts.tags,
+          // A genuine top-level root is its own lineage origin, so
+          // origin == branch == parent == id here. Every descendant id
+          // extends it as `{id}:{lineage}`.
           "resonate:origin": id,
-          // A genuine top-level root is its own lineage origin AND its own
-          // id-generation prefix; the prefix then propagates down unchanged.
-          "resonate:prefix": id,
           "resonate:branch": id,
           "resonate:parent": id,
           "resonate:scope": "global",
@@ -475,7 +472,14 @@ export class Resonate {
       version: registered ? registered.version : opts.version || 1,
     });
 
-    await this.schedules.create(name, cron, `${this.idPrefix}{{.id}}.{{.timestamp}}`, opts.timeout, {
+    // Each firing creates a root promise named from this id, so the schedule
+    // name is bound by the same rules as a run/rpc id. The server stamps the
+    // *whole* templated id onto the fired promise's resonate:origin tag, so
+    // the template must join with a plain '-': a '.' would make every child
+    // of a scheduled run rejected (dot_in_origin) and a ':' would hide the
+    // timestamp below the origin, collapsing every firing onto one lineage.
+    validateRootId(name);
+    await this.schedules.create(name, cron, "{{.id}}-{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,
       promiseData: data,
       promiseTags: { ...opts.tags, "resonate:target": opts.target },
@@ -487,7 +491,8 @@ export class Resonate {
   }
 
   public async get<T = any>(id: string): Promise<ResonateHandle<T>> {
-    id = `${this.idPrefix}${id}`;
+    // get is a lookup, not a create: it takes any id, including a child's
+    // (e.g. "wf:1.2"), so it deliberately does NOT validate.
     const promise = await this.promiseGet({
       kind: "promise.get",
       head: { corrId: randomUUID(), version: util.VERSION },

--- a/src/resonate.ts
+++ b/src/resonate.ts
@@ -305,8 +305,8 @@ export class Resonate {
 
     // Validated at the call site that named the workflow, rather than
     // surfacing later as an opaque 400 from the server: the id becomes the
-    // origin of its whole lineage, so the reserved separators ('.' and ':')
-    // are rejected outright.
+    // origin of its whole lineage, so ':' is rejected outright ('.' is only
+    // read below the origin).
     validateRootId(id);
 
     util.assert(registered.version > 0, "function version must be greater than zero");
@@ -475,9 +475,10 @@ export class Resonate {
     // Each firing creates a root promise named from this id, so the schedule
     // name is bound by the same rules as a run/rpc id. The server stamps the
     // *whole* templated id onto the fired promise's resonate:origin tag, so
-    // the template must join with a plain '-': a '.' would make every child
-    // of a scheduled run rejected (dot_in_origin) and a ':' would hide the
-    // timestamp below the origin, collapsing every firing onto one lineage.
+    // the template must join with a plain '-': a ':' would hide the timestamp
+    // below the origin, collapsing every firing onto one lineage. A '.' is
+    // fine now — it is only read below the origin — but '-' keeps the
+    // timestamp clearly distinct from any dots in the schedule name.
     validateRootId(name);
     await this.schedules.create(name, cron, "{{.id}}-{{.timestamp}}", opts.timeout, {
       promiseHeaders: headers,

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import type { Codec } from "./codec.js";
 import type { InnerContext } from "./context.js";
 import exceptions from "./exceptions.js";
+import { joinId } from "./ids.js";
 import type { Logger } from "./logger.js";
 import {
   isSuccess,
@@ -112,12 +113,15 @@ function cyrb53(input: string | Uint8Array, seed = 0): number {
   return 4294967296 * (2097151 & h2) + (h1 >>> 0);
 }
 
-export function detachedId(prefix: string, seqid: string): string {
-  // `${prefix}.d${hash}` -- the `d` marks the segment as a detached child (vs an
-  // rfi child's numeric `.${seq}`). `prefix` is the id-generation prefix
-  // (resonate:prefix), set once at the top and propagated down unchanged, so
-  // recursive detached ids stay bounded at one segment past the prefix.
-  return `${prefix}.d${cyrb53(seqid).toString(16).padStart(14, "0")}`;
+export function detachedId(origin: string, seqid: string): string {
+  // `${origin}:d${hash}` -- the `d` marks the segment as a detached child (vs a
+  // child's numeric `.${seq}`). `origin` is the lineage origin, set once at the
+  // top and propagated down unchanged forever, so recursive detached ids stay
+  // bounded at one segment past the origin instead of growing a segment per
+  // level. The child keeps the parent's origin rather than re-rooting onto its
+  // own id: the server derives the origin as everything before the first `:`
+  // and requires every id in a lineage to start with `{origin}:`.
+  return joinId(origin, `d${cyrb53(seqid).toString(16).padStart(14, "0")}`);
 }
 
 export function getCallerInfo(): string {

--- a/tests/async/async-trace.test.ts
+++ b/tests/async/async-trace.test.ts
@@ -52,7 +52,7 @@ function newCore(registry: Registry, network: LocalNetwork): Core {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (target: string) => target, idPrefix: "" }),
+    optsBuilder: new OptionsBuilder({ match: (target: string) => target }),
     logger: new ConsoleLogger("error"),
   });
 }
@@ -167,12 +167,12 @@ describe("async engine lifecycle trace", () => {
 
     // run main -> main.0
     const run = t.find((e) => e.kind === "run");
-    expect(run).toEqual({ kind: "run", id: "main", callee: "main.0" });
+    expect(run).toEqual({ kind: "run", id: "main", callee: "main:0" });
 
     // Child spawns once and returns 7.
     expect(counts(t).spawn.filter((e) => e.id !== "main").length).toBe(1);
-    const childReturn = t.find((e) => e.kind === "return" && e.id === "main.0");
-    expect(childReturn).toEqual({ kind: "return", id: "main.0", state: "resolved", value: 7 });
+    const childReturn = t.find((e) => e.kind === "return" && e.id === "main:0");
+    expect(childReturn).toEqual({ kind: "return", id: "main:0", state: "resolved", value: 7 });
 
     // Root return is last.
     expect(t[t.length - 1]).toEqual({ kind: "return", id: "main", state: "resolved", value: 7 });
@@ -237,7 +237,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.state).toBe("rejected");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn.kind === "return" && rootReturn.state).toBe("rejected");
@@ -264,7 +264,7 @@ describe("async engine lifecycle trace", () => {
     expect(res.kind).toBe("done");
     if (res.kind === "done") expect(res.value).toBe("caught:kaboom");
 
-    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main.0");
+    const childReturn = res.trace.find((e) => e.kind === "return" && e.id === "main:0");
     expect(childReturn?.kind === "return" && childReturn.state).toBe("rejected");
     const rootReturn = res.trace[res.trace.length - 1];
     expect(rootReturn).toMatchObject({ kind: "return", id: "main", state: "resolved" });
@@ -279,12 +279,12 @@ describe("async engine lifecycle trace", () => {
     const res = await runRoot(fns, "main");
 
     expect(res.kind).toBe("suspended");
-    if (res.kind === "suspended") expect(res.awaited).toEqual(["main.0"]);
+    if (res.kind === "suspended") expect(res.awaited).toEqual(["main:0"]);
     const t = res.trace;
 
     expect(t[0]).toEqual({ kind: "spawn", id: "main" });
-    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main.0" });
-    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main.0" });
+    expect(t.find((e) => e.kind === "rpc")).toEqual({ kind: "rpc", id: "main", callee: "main:0" });
+    expect(t.find((e) => e.kind === "block")).toEqual({ kind: "block", id: "main:0" });
     expect(t[t.length - 1]).toEqual({ kind: "suspend", id: "main" });
 
     expectLifecycleWellFormed(t);
@@ -355,7 +355,7 @@ describe("async engine lifecycle trace", () => {
 
       // Pre-settle the child (main.0) so the engine's create dedups against it.
       const effects = util.buildEffects(network.send, codec, { id: task.id, version: task.version });
-      await presettle(effects, "main.0", 99);
+      await presettle(effects, "main:0", 99);
 
       const res = await core.executeUntilBlocked(task, promise, preload);
 
@@ -363,10 +363,10 @@ describe("async engine lifecycle trace", () => {
       if (res.kind === "done") expect(res.value).toBe(99); // deduped to the stored value
 
       const c = counts(res.trace);
-      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main.0" }]);
+      expect(c.run).toEqual([{ kind: "run", id: "main", callee: "main:0" }]);
       expect(c.dedup.length).toBe(1);
-      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main.0", state: "resolved" });
-      expect(c.spawn.filter((e) => e.id === "main.0").length).toBe(0); // deduped, never spawned
+      expect(c.dedup[0]).toMatchObject({ kind: "dedup", id: "main:0", state: "resolved" });
+      expect(c.spawn.filter((e) => e.id === "main:0").length).toBe(0); // deduped, never spawned
 
       expectLifecycleWellFormed(res.trace);
     } finally {

--- a/tests/async/async.test.ts
+++ b/tests/async/async.test.ts
@@ -174,8 +174,8 @@ describe("Resonate — async/await engine", () => {
 
     await (await resonate.run("createorder", fanout)).result();
 
-    const children = recording.creates.filter((id) => id.startsWith("createorder."));
-    expect(children).toEqual(["createorder.0", "createorder.1", "createorder.2", "createorder.3"]);
+    const children = recording.creates.filter((id) => id.startsWith("createorder:"));
+    expect(children).toEqual(["createorder:0", "createorder:1", "createorder:2", "createorder:3"]);
   });
 
   test("hang model: a suspending pass never enters the surrounding try/catch", async () => {
@@ -287,7 +287,7 @@ describe("Resonate — async/await engine", () => {
 
     const handle = await resonate.run("dpc-1", wf);
     await sleep(100); // ensure the latent promise dpc-1.0 has been created
-    await resonate.promises.resolve("dpc-1.0", { data: codec.encode("signal").data });
+    await resonate.promises.resolve("dpc-1:0", { data: codec.encode("signal").data });
 
     expect(await handle.result()).toBe("signal");
   });
@@ -307,7 +307,7 @@ describe("Resonate — async/await engine", () => {
     expect(await (await resonate.get<number>(childId)).result()).toBe(50);
   });
 
-  test("resonate:prefix is set at the root and propagates to every child create", async () => {
+  test("child ids extend the origin and no resonate:prefix tag is emitted", async () => {
     const recording = new RecordingNetwork(new LocalNetwork({ pid: "default", group: "default" }));
     resonate = new Resonate({ network: recording, ttl: Number.MAX_SAFE_INTEGER });
     resonate.register("pchild", async (_info: Info, n: number): Promise<number> => n);
@@ -322,20 +322,28 @@ describe("Resonate — async/await engine", () => {
 
     await (await resonate.run("prefix-1", wf)).result();
 
-    expect(recording.tags.get("prefix-1")?.["resonate:prefix"]).toBe("prefix-1"); // root
-    expect(recording.tags.get("prefix-1.0")?.["resonate:prefix"]).toBe("prefix-1"); // local child
-    expect(recording.tags.get("prefix-1.1")?.["resonate:prefix"]).toBe("prefix-1"); // sleep timer
-    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1.d"));
-    expect(detachedId).toMatch(/^prefix-1\.d[0-9a-f]{14}$/);
-    expect(recording.tags.get(detachedId as string)?.["resonate:prefix"]).toBe("prefix-1");
+    // A bare root joins its first lineage segment with ':' -- deeper segments
+    // would join with '.'.
+    expect(recording.tags.get("prefix-1")?.["resonate:origin"]).toBe("prefix-1"); // root
+    expect(recording.tags.get("prefix-1:0")?.["resonate:origin"]).toBe("prefix-1"); // local child
+    expect(recording.tags.get("prefix-1:1")?.["resonate:origin"]).toBe("prefix-1"); // sleep timer
+    const detachedId = recording.creates.find((id) => id.startsWith("prefix-1:d"));
+    expect(detachedId).toMatch(/^prefix-1:d[0-9a-f]{14}$/);
+    // Detached keeps the parent's origin and declares it as its parent.
+    expect(recording.tags.get(detachedId as string)?.["resonate:origin"]).toBe("prefix-1");
+    expect(recording.tags.get(detachedId as string)?.["resonate:parent"]).toBe("prefix-1");
+    // The resonate:prefix tag is gone.
+    for (const id of recording.creates) {
+      expect(recording.tags.get(id)?.["resonate:prefix"]).toBeUndefined();
+    }
   });
 
-  test("nested detached ids stay bounded via the fixed prefix", async () => {
+  test("nested detached ids stay bounded via the fixed origin", async () => {
     resonate = newResonate();
-    const seen: { id: string; prefixId: string; originId: string }[] = [];
+    const seen: { id: string; originId: string }[] = [];
     const deepest = Promise.withResolvers<void>();
     const nest = async (ctx: Context, depth: number): Promise<void> => {
-      seen.push({ id: ctx.id, prefixId: ctx.prefixId, originId: ctx.originId });
+      seen.push({ id: ctx.id, originId: ctx.originId });
       if (depth >= 3) {
         deepest.resolve();
         return;
@@ -349,13 +357,11 @@ describe("Resonate — async/await engine", () => {
 
     expect(seen).toHaveLength(3);
     expect(seen[0].id).toBe("nest-root");
-    // Every level keeps the top-level root as its id-generation prefix, so each
-    // detached id is exactly one `.d` segment past it — bounded at any depth.
-    for (const s of seen) expect(s.prefixId).toBe("nest-root");
-    expect(seen[1].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
-    expect(seen[2].id).toMatch(/^nest-root\.d[0-9a-f]{14}$/);
-    // The detached re-root breaks lineage: origin resets to its own id.
-    expect(seen[1].originId).toBe(seen[1].id);
+    // Every level keeps the top-level root as its lineage origin, so each
+    // detached id is exactly one `:d` segment past it — bounded at any depth.
+    for (const s of seen) expect(s.originId).toBe("nest-root");
+    expect(seen[1].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
+    expect(seen[2].id).toMatch(/^nest-root:d[0-9a-f]{14}$/);
   });
 
   test("ctx.panic aborts the pass: execution stops and nothing settles", async () => {
@@ -420,7 +426,7 @@ describe("Resonate — async/await engine", () => {
 
     // Neither the root nor the (created) child promise settles.
     expect((await resonate.promises.get("panic-3")).state).toBe("pending");
-    expect((await resonate.promises.get("panic-3.0")).state).toBe("pending");
+    expect((await resonate.promises.get("panic-3:0")).state).toBe("pending");
   });
 
   test("ctx.panic(false) and ctx.assert(true) do not abort", async () => {

--- a/tests/async/core.test.ts
+++ b/tests/async/core.test.ts
@@ -59,7 +59,7 @@ function buildCore(fns: Record<string, AnyFunc>): {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (t: string) => t, idPrefix: "test-" }),
+    optsBuilder: new OptionsBuilder({ match: (t: string) => t }),
     logger: new ConsoleLogger("error"),
   });
 
@@ -212,16 +212,16 @@ describe("AsyncCore", () => {
 
       expect(res.kind).toBe("suspended");
       if (res.kind === "suspended") {
-        expect(res.awaited).toContain("p4.0");
-        expect(res.awaited).toContain("p4.1");
+        expect(res.awaited).toContain("p4:0");
+        expect(res.awaited).toContain("p4:1");
       }
 
       const suspend = sent.find((r) => r.kind === "task.suspend");
       expect(suspend).toBeDefined();
       if (suspend && suspend.kind === "task.suspend") {
         const awaitedIds = suspend.data.actions.map((a) => a.data.awaited);
-        expect(awaitedIds).toContain("p4.0");
-        expect(awaitedIds).toContain("p4.1");
+        expect(awaitedIds).toContain("p4:0");
+        expect(awaitedIds).toContain("p4:1");
       }
     });
 
@@ -244,7 +244,7 @@ describe("AsyncCore", () => {
           await origFn({
             kind: "promise.settle",
             head: { corrId: randomUUID(), version: VERSION },
-            data: { id: "p5.0", state: "resolved", value: codec.encode(7) },
+            data: { id: "p5:0", state: "resolved", value: codec.encode(7) },
           });
           return {
             kind: "task.suspend",
@@ -357,7 +357,7 @@ describe("AsyncCore", () => {
       const fence = creates[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-1.0");
+      expect(fence.data.action.data.id).toBe("fence-1:0");
 
       // Ensure no bare promise.create was sent during execution
       expect(sent.some((r) => r.kind === "promise.create")).toBe(false);
@@ -380,7 +380,7 @@ describe("AsyncCore", () => {
       const fence = settles[0];
       expect(fence.data.id).toBe(task.id);
       expect(fence.data.version).toBe(task.version);
-      expect(fence.data.action.data.id).toBe("fence-2.0");
+      expect(fence.data.action.data.id).toBe("fence-2:0");
 
       // No bare promise.settle should have been sent during execution
       expect(sent.some((r) => r.kind === "promise.settle")).toBe(false);

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -115,28 +115,25 @@ describe("Resonate usage tests", () => {
     resonate.register("bar", bar);
     resonate.register("baz", baz);
 
-    expect(await res(resonate.run("foo.1", foo))).toBe("hello");
-    expect((await resonate.promises.get("foo.1")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect(await res(resonate.run("foo1", foo))).toBe("hello");
+    expect((await resonate.promises.get("foo1")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1:0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1:0",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+    expect((await resonate.promises.get("foo1:0.0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1:0.0",
+      "resonate:parent": "foo1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -149,27 +146,24 @@ describe("Resonate usage tests", () => {
     const foo = async (ctx: Context): Promise<string> => ctx.run(bar);
     const f = resonate.register("lfcfoo", foo);
 
-    expect(await res(f.run("foo.1"))).toBe("hello");
-    expect((await resonate.promises.get("foo.1")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect(await res(f.run("foo1"))).toBe("hello");
+    expect((await resonate.promises.get("foo1")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1:0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+    expect((await resonate.promises.get("foo1:0.0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1:0",
       "resonate:scope": "local",
     });
   });
@@ -186,7 +180,7 @@ describe("Resonate usage tests", () => {
     expect(await h.done()).toBe(false);
 
     await sleep(100); // ensure the latent promise done-1.0 exists
-    await resonate.promises.resolve("done-1.0", { data: codec.encode("v").data });
+    await resonate.promises.resolve("done-1:0", { data: codec.encode("v").data });
     expect(await h.result()).toBe("v");
     expect(await h.done()).toBe(true);
 
@@ -349,15 +343,15 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("opts-1.0");
+      expect(fu.id).toBe("opts-1:0");
       return fu;
     };
     resonate.register("optswf", wf);
 
     const v = await res(resonate.run("opts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("opts-1.0");
-    expect(durable.id).toBe("opts-1.0");
+    const durable = await resonate.promises.get("opts-1:0");
+    expect(durable.id).toBe("opts-1:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
   });
 
@@ -370,21 +364,20 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<{ msg: string }> => {
       const fu = ctx.run(g, "this is a function");
-      expect(fu.id).toBe("noopts-1.0");
+      expect(fu.id).toBe("noopts-1:0");
       return fu;
     };
     resonate.register("nooptswf", wf);
 
     const v = await res(resonate.run("noopts-1", wf));
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("noopts-1.0");
-    expect(durable.id).toBe("noopts-1.0");
+    const durable = await resonate.promises.get("noopts-1:0");
+    expect(durable.id).toBe("noopts-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "noopts-1",
       "resonate:parent": "noopts-1",
       "resonate:origin": "noopts-1",
-      "resonate:prefix": "noopts-1",
     });
   });
 
@@ -400,7 +393,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await res(resonate.rpc(`t${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`t${i}`);
-      const p2 = await resonate.promises.get(`t${i}.0`);
+      const p2 = await resonate.promises.get(`t${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -418,7 +411,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await res(resonate.rpc(`u${i}`, "tfoo", target, resonate.options({ target })));
       const p1 = await resonate.promises.get(`u${i}`);
-      const p2 = await resonate.promises.get(`u${i}.0`);
+      const p2 = await resonate.promises.get(`u${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -430,7 +423,7 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>();
-      expect(fu.id).toBe("hitl-1.0");
+      expect(fu.id).toBe("hitl-1:0");
       return fu;
     };
     resonate.register("hitlwf", wf);
@@ -438,12 +431,11 @@ describe("Resonate usage tests", () => {
     const h = await resonate.run("hitl-1", wf);
     await sleep(100); // ensure hitl-1.0 promise is created
 
-    await resonate.promises.resolve("hitl-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("hitl-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
-    expect((await resonate.promises.get("hitl-1.0")).tags).toEqual({
-      "resonate:branch": "hitl-1.0",
+    expect((await resonate.promises.get("hitl-1:0")).tags).toEqual({
+      "resonate:branch": "hitl-1:0",
       "resonate:origin": "hitl-1",
-      "resonate:prefix": "hitl-1",
       "resonate:parent": "hitl-1",
       "resonate:scope": "global",
     });
@@ -456,7 +448,7 @@ describe("Resonate usage tests", () => {
 
     const wf = async (ctx: Context): Promise<string> => {
       const fu = ctx.promise<string>({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("timeout-1.0");
+      expect(fu.id).toBe("timeout-1:0");
       return fu;
     };
     resonate.register("timeoutwf", wf);
@@ -464,17 +456,16 @@ describe("Resonate usage tests", () => {
     const h = await resonate.run("timeout-1", wf);
     await sleep(100); // ensure timeout-1.0 promise is created
 
-    const durable = await resonate.promises.get("timeout-1.0");
+    const durable = await resonate.promises.get("timeout-1:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "timeout-1.0",
+      "resonate:branch": "timeout-1:0",
       "resonate:origin": "timeout-1",
-      "resonate:prefix": "timeout-1",
       "resonate:parent": "timeout-1",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("timeout-1.0", { data: codec.encode("myValue").data });
+    await resonate.promises.resolve("timeout-1:0", { data: codec.encode("myValue").data });
     expect(await h.result()).toBe("myValue");
   });
 
@@ -491,14 +482,16 @@ describe("Resonate usage tests", () => {
     const h = await resonate.run("sleep-1", wf);
     await sleep(100); // ensure sleep-1.0 promise is created
 
-    const durable = await resonate.promises.get("sleep-1.0");
+    const durable = await resonate.promises.get("sleep-1:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "sleep-1.0",
+      "resonate:branch": "sleep-1:0",
       "resonate:origin": "sleep-1",
-      "resonate:prefix": "sleep-1",
       "resonate:parent": "sleep-1",
       "resonate:scope": "global",
+      // The server only schedules a timeout for a promise carrying a target,
+      // so a target-less timer would never fire — the timer must carry one.
+      "resonate:target": "local://any@default",
     });
     expect(durable.timeoutAt).toBeLessThan(time + 1 * util.SEC + 100);
 
@@ -581,14 +574,13 @@ describe("Resonate usage tests", () => {
     resonate.register("twf1", wf);
 
     await res(resonate.run("tdef-1", wf));
-    const durable = await resonate.promises.get("tdef-1.0");
-    expect(durable.id).toBe("tdef-1.0");
+    const durable = await resonate.promises.get("tdef-1:0");
+    expect(durable.id).toBe("tdef-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "tdef-1.0",
+      "resonate:branch": "tdef-1:0",
       "resonate:parent": "tdef-1",
       "resonate:origin": "tdef-1",
-      "resonate:prefix": "tdef-1",
       "resonate:target": "local://any@default",
     });
   });
@@ -604,13 +596,12 @@ describe("Resonate usage tests", () => {
     resonate.register("twf2", wf);
 
     await res(resonate.run("topt-1", wf));
-    const durable = await resonate.promises.get("topt-1.0");
+    const durable = await resonate.promises.get("topt-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "topt-1.0",
+      "resonate:branch": "topt-1:0",
       "resonate:parent": "topt-1",
       "resonate:origin": "topt-1",
-      "resonate:prefix": "topt-1",
       "resonate:target": "local://any@remoteTarget",
     });
   });
@@ -626,13 +617,12 @@ describe("Resonate usage tests", () => {
     resonate.register("twf3", wf);
 
     await res(resonate.run("turl-1", wf));
-    const durable = await resonate.promises.get("turl-1.0");
+    const durable = await resonate.promises.get("turl-1:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "turl-1.0",
+      "resonate:branch": "turl-1:0",
       "resonate:parent": "turl-1",
       "resonate:origin": "turl-1",
-      "resonate:prefix": "turl-1",
       "resonate:target": "http://faasurl.com",
     });
   });
@@ -654,7 +644,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "troot-1",
       "resonate:parent": "troot-1",
       "resonate:origin": "troot-1",
-      "resonate:prefix": "troot-1",
       "resonate:target": "http://faasurl.com",
     });
   });
@@ -675,7 +664,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "troot-2",
       "resonate:parent": "troot-2",
       "resonate:origin": "troot-2",
-      "resonate:prefix": "troot-2",
       "resonate:target": "local://any@default",
     });
   });
@@ -830,46 +818,29 @@ describe("Resonate usage tests", () => {
     // awaited out of band by id.
     expect(new Set(ids).size).toBe(2);
     for (const id of ids) {
-      expect(id).toMatch(/^equiv-1\.d[0-9a-f]+$/);
+      expect(id).toMatch(/^equiv-1:d[0-9a-f]+$/);
       expect(await (await resonate.get<string>(id)).result()).toBe("bar");
     }
   });
 
-  test("Using prefix at Resonate class prefixes all the promises", async () => {
-    const prefix = "myPrefix";
-    resonate = new Resonate({ prefix });
+  test("run/rpc/schedule reject an invalid root id; get does not validate", async () => {
+    // Raised at the call site, before anything reaches the server: a root id
+    // becomes the origin of its whole lineage, so the reserved separators
+    // ('.' and ':') are rejected outright.
+    resonate = newResonate();
+    const noop = async (_ctx: Context): Promise<string> => "ok";
+    resonate.register("vnoop", noop);
 
-    const qux = async (info: Info): Promise<string> => {
-      expect(info.id.startsWith(prefix)).toBe(true);
-      expect(info.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "qux";
-    };
+    for (const bad of ["bad.id", "bad:id", "", "bad\u0000id"]) {
+      await expect(resonate.run(bad, noop)).rejects.toThrow(/Invalid id/);
+      await expect(resonate.rpc(bad, "vnoop")).rejects.toThrow(/Invalid id/);
+      await expect(resonate.schedule(bad, "* * * * *", "vnoop")).rejects.toThrow(/Invalid id/);
+    }
 
-    const baz = async (ctx: Context): Promise<string> => {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      await ctx.run(qux);
-      return "baz";
-    };
-
-    const bar = async (ctx: Context): Promise<string> => {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "bar";
-    };
-
-    const foo = async (ctx: Context): Promise<string> => {
-      const p = ctx.run(bar);
-      await ctx.run(baz);
-      await ctx.run(qux);
-      await p;
-      return "ok";
-    };
-    const f = resonate.register("pfxfoo", foo);
-
-    const h = await f.run("fooId");
-    expect(h.id).toBe(`${prefix}:fooId`);
-    expect(await h.result()).toBe("ok");
+    // get is a lookup, not a create: it takes any id, including a child's
+    // (e.g. "wf:1.2"), so it must NOT validate. A missing one 404s rather
+    // than raising InvalidId.
+    await expect(resonate.get("wf:1.2")).rejects.toThrow(/not found|404|exist/i);
   });
 });
 

--- a/tests/async/resonate.test.ts
+++ b/tests/async/resonate.test.ts
@@ -825,13 +825,13 @@ describe("Resonate usage tests", () => {
 
   test("run/rpc/schedule reject an invalid root id; get does not validate", async () => {
     // Raised at the call site, before anything reaches the server: a root id
-    // becomes the origin of its whole lineage, so the reserved separators
-    // ('.' and ':') are rejected outright.
+    // becomes the origin of its whole lineage, so ':' is rejected outright
+    // ('.' is only read below the origin).
     resonate = newResonate();
     const noop = async (_ctx: Context): Promise<string> => "ok";
     resonate.register("vnoop", noop);
 
-    for (const bad of ["bad.id", "bad:id", "", "bad\u0000id"]) {
+    for (const bad of ["bad:id", "", "bad\u0000id"]) {
       await expect(resonate.run(bad, noop)).rejects.toThrow(/Invalid id/);
       await expect(resonate.rpc(bad, "vnoop")).rejects.toThrow(/Invalid id/);
       await expect(resonate.schedule(bad, "* * * * *", "vnoop")).rejects.toThrow(/Invalid id/);

--- a/tests/async/structured-concurrency.test.ts
+++ b/tests/async/structured-concurrency.test.ts
@@ -50,7 +50,7 @@ function newCore(registry: Registry, network: LocalNetwork): Core {
     registry,
     heartbeat: new NoopHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (target: string) => target, idPrefix: "" }),
+    optsBuilder: new OptionsBuilder({ match: (target: string) => target }),
     logger: new ConsoleLogger("error"),
   });
 }
@@ -127,8 +127,8 @@ describe("async engine structured concurrency", () => {
       expect(status.kind).toBe("done");
       if (status.kind !== "done") return;
       expect(status.value).toBe("done");
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire.0");
-      const rec = await getPromise(network, "sc-fire.0");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-fire:0");
+      const rec = await getPromise(network, "sc-fire:0");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("side-effect");
     } finally {
@@ -156,13 +156,13 @@ describe("async engine structured concurrency", () => {
       // The pass suspends on the timer only; the chained locals both completed.
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-local.0"]);
+      expect(status.awaited).toEqual(["sc-local:0"]);
 
       // The chained run finished INSIDE the pass: its return event is in the
       // trace (not emitted after getTrace) and its durable promise is settled
       // before executeUntilBlocked returned (no settle racing task.suspend).
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local.2");
-      const rec = await getPromise(network, "sc-local.2");
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-local:2");
+      const rec = await getPromise(network, "sc-local:2");
       expect(rec?.state).toBe("resolved");
       expect(rec?.value?.data).toBe("b:a");
     } finally {
@@ -189,7 +189,7 @@ describe("async engine structured concurrency", () => {
       // todo was lost (self-healing on resume, but a missed callback).
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect([...status.awaited].sort()).toEqual(["sc-remote.0", "sc-remote.2"]);
+      expect([...status.awaited].sort()).toEqual(["sc-remote:0", "sc-remote:2"]);
     } finally {
       await network.stop();
     }
@@ -216,9 +216,9 @@ describe("async engine structured concurrency", () => {
 
       expect(status.kind).toBe("suspended");
       if (status.kind !== "suspended") return;
-      expect(status.awaited).toEqual(["sc-hops.0"]);
-      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops.2");
-      expect((await getPromise(network, "sc-hops.2"))?.state).toBe("resolved");
+      expect(status.awaited).toEqual(["sc-hops:0"]);
+      expect(returnsOf(status.trace).map((e) => e.id)).toContain("sc-hops:2");
+      expect((await getPromise(network, "sc-hops:2"))?.state).toBe("resolved");
     } finally {
       await network.stop();
     }
@@ -247,7 +247,7 @@ describe("async engine structured concurrency", () => {
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
       // The panicked op never reached the server: no child promise was created.
-      expect(await getPromise(network, "sc-zombie.1")).toBeUndefined();
+      expect(await getPromise(network, "sc-zombie:1")).toBeUndefined();
     } finally {
       await network.stop();
     }
@@ -276,7 +276,7 @@ describe("async engine structured concurrency", () => {
 
       await delay(120);
       expect(String(leaked)).toContain("after the pass ended");
-      expect(await getPromise(network, "sc-done.0")).toBeUndefined();
+      expect(await getPromise(network, "sc-done:0")).toBeUndefined();
     } finally {
       await network.stop();
     }

--- a/tests/computation.test.ts
+++ b/tests/computation.test.ts
@@ -66,7 +66,7 @@ async function buildComputation(registry: Registry): Promise<{
     registry,
     new TestHeartbeat(),
     new Map(),
-    new OptionsBuilder({ match: (target: string) => target, idPrefix: "test-" }),
+    new OptionsBuilder({ match: (target: string) => target }),
     logger,
   );
 

--- a/tests/core.test.ts
+++ b/tests/core.test.ts
@@ -76,7 +76,7 @@ function buildCore(opts: {
     registry: new Registry(),
     heartbeat: new TestHeartbeat(),
     dependencies: new Map(),
-    optsBuilder: new OptionsBuilder({ match: (t: string) => t, idPrefix: "test-" }),
+    optsBuilder: new OptionsBuilder({ match: (t: string) => t }),
     logger,
   });
 

--- a/tests/coroutine.test.ts
+++ b/tests/coroutine.test.ts
@@ -98,7 +98,7 @@ describe("Coroutine", () => {
         timeout: 0,
         version: 1,
         retryPolicy: new Never(),
-        optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+        optsBuilder: new OptionsBuilder({ match: (t) => t }),
       }),
       func,
       args,
@@ -140,7 +140,7 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
@@ -165,7 +165,7 @@ describe("Coroutine", () => {
     const effects = buildEffects(network);
 
     // Completes in one execution — no suspension for locals
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 31458 } });
   });
 
@@ -186,13 +186,13 @@ describe("Coroutine", () => {
     const network = new DummyNetwork();
     const effects = buildEffects(network);
 
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
-    r = await exec("foo.1", foo, [], effects);
+    await completePromise(effects, "foo:1.1", { kind: "value", value: 42 });
+    r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
@@ -205,21 +205,21 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
-    r = await exec("foo.1", foo, [], effects);
+    await completePromise(effects, "foo:1.1", { kind: "value", value: 42 });
+    r = await exec("foo:1", foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
-    r = await exec("foo.1", foo, [], effects);
+    await completePromise(effects, "foo:1.0", { kind: "value", value: 42 });
+    r = await exec("foo:1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
   });
@@ -245,7 +245,7 @@ describe("Coroutine", () => {
     const effects = buildEffects(network);
 
     // Locals are flushed at return → completes in single execution
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
   });
 
@@ -268,16 +268,16 @@ describe("Coroutine", () => {
 
     // First execution: local is flushed and settled inline at return,
     // but remote is still pending → suspended with 1 remote todo
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
     expect(r.type).toBe("suspended");
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo:1.1", { kind: "value", value: 42 });
 
     // Second execution: everything resolved → done
-    r = await exec("foo.1", foo, [], effects);
+    r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 77 } });
   });
 
@@ -300,7 +300,7 @@ describe("Coroutine", () => {
 
     // The child generator completes inline, so no pending todos exist when
     // foo returns → should complete in a single execution without suspending.
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 88 } });
   });
 
@@ -313,14 +313,14 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.0", { kind: "value", value: 42 });
-    r = await exec("foo.1", foo, [], effects);
+    await completePromise(effects, "foo:1.0", { kind: "value", value: 42 });
+    r = await exec("foo:1", foo, [], effects);
 
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 99 } });
   });
@@ -335,13 +335,14 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const id = util.detachedId("foo", "foo.1");
+    const id = util.detachedId("foo", "foo:1");
     let r = await exec(id, foo, [], effects);
 
     expect(r.type).toBe("suspended");
     r = r as Suspended;
     expect(r.todo.remote).toHaveLength(2);
 
+    // The exec root id already carries a ':', so its children join with '.'.
     await completePromise(effects, `${id}.0`, { kind: "value", value: 42 });
     r = await exec(id, foo, [], effects);
 
@@ -355,18 +356,16 @@ describe("Coroutine", () => {
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
-  test("detached id stays bounded across recursive re-root", () => {
-    // A detached workflow runs as its own root: resonate:origin is reset to its
-    // own id (a fresh lineage). Recursive detached ids stay bounded NOT via
-    // origin but via resonate:prefix, propagated unchanged across re-roots. Were
-    // the id minted off the (grown) origin, each level would add a `.d${hash}`
-    // segment without bound; rooting it on the pinned prefix keeps it at
-    // `${prefix}.d${hash}` -- one segment past the prefix, at every depth.
-    const grownId = "top.deadbeefdeadbe"; // a workflow already several detached levels deep
+  test("detached id stays bounded across recursive detachment", () => {
+    // A detached child keeps the parent's ORIGIN and mints its id off it
+    // (`${origin}:d${hash}`), so recursion stays bounded at one segment past
+    // the origin instead of growing a segment per level. The origin is also
+    // the resonate:parent it declares -- the id hangs off the origin, not off
+    // the spawning context -- while resonate:branch stays the child's own id.
+    const grownId = "top:deadbeefdeadbe"; // a workflow already one detached level deep
     const ctx = new InnerContext({
       id: grownId,
-      oId: grownId, // detached re-roots origin to its own (grown) id
-      prId: "top", // the id-generation prefix is still pinned to the top
+      oId: "top", // the lineage origin, fixed at the top and carried unchanged
       func: "fires",
       clock: new WallClock(),
       registry: new Registry(),
@@ -374,37 +373,37 @@ describe("Coroutine", () => {
       timeout: 0,
       version: 1,
       retryPolicy: new Never(),
-      optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+      optsBuilder: new OptionsBuilder({ match: (t) => t }),
     });
 
     const rfi = ctx.detached("fires");
 
-    // The detached id is rooted at the pinned PREFIX "top", exactly one segment
-    // past it -- NOT the grown id (which would add a segment per level).
+    // The detached id is rooted at the ORIGIN "top", exactly one segment past
+    // it -- NOT the grown id (which would add a segment per level).
     expect(rfi.id).toBe(util.detachedId("top", `${grownId}.0`));
-    expect(rfi.id.startsWith("top.d")).toBe(true);
-    expect(rfi.id.split(".")).toHaveLength(2);
+    expect(rfi.id.startsWith("top:d")).toBe(true);
+    expect(rfi.id.split(":")).toHaveLength(2);
 
-    // The prefix carries forward unchanged, bounding the next level; the child's
-    // lineage origin is its OWN id (a fresh lineage root).
-    expect(rfi.createReq.data.tags?.["resonate:prefix"]).toBe("top");
-    expect(rfi.createReq.data.tags?.["resonate:origin"]).toBe(rfi.id);
+    // The origin carries forward unchanged, bounding the next level, and is
+    // the declared ancestor; the branch is the child's own id.
+    expect(rfi.createReq.data.tags?.["resonate:origin"]).toBe("top");
+    expect(rfi.createReq.data.tags?.["resonate:parent"]).toBe("top");
+    expect(rfi.createReq.data.tags?.["resonate:branch"]).toBe(rfi.id);
   });
 
   test("recursive multi-detached keeps every id at the same bounded length", () => {
     // End-to-end proof: fan out FANOUT detached per workflow, DEPTH levels deep,
-    // re-rooting each child exactly as production does -- a detached promise
-    // executes as its own root with oId = its resonate:origin tag (its own id)
-    // and prId = its resonate:prefix tag (computation.ts). The id is
-    // `${prefix}.d${cyrb53(seqid).padStart(14)}`: the hash flattens the
-    // (ever-growing) seqid to a constant 14 chars, and the prefix tag keeps the
-    // prefix pinned to the top, so it never grows. Net: every detached id at
-    // every depth is exactly `${top}.d${14hex}` -- bounded regardless of depth.
-    const makeCtx = (id: string, oId: string, prId: string) =>
+    // re-seeding each child exactly as production does -- a detached promise
+    // executes with oId = its resonate:origin tag (the parent's origin,
+    // carried unchanged). The id is `${origin}:d${cyrb53(seqid).padStart(14)}`:
+    // the hash flattens the (ever-growing) seqid to a constant 14 chars, and
+    // the origin stays pinned to the top, so it never grows. Net: every
+    // detached id at every depth is exactly `${top}:d${14hex}` -- bounded
+    // regardless of depth.
+    const makeCtx = (id: string, oId: string) =>
       new InnerContext({
         id,
         oId,
-        prId,
         func: "fires",
         clock: new WallClock(),
         registry: new Registry(),
@@ -412,7 +411,7 @@ describe("Coroutine", () => {
         timeout: 0,
         version: 1,
         retryPolicy: new Never(),
-        optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+        optsBuilder: new OptionsBuilder({ match: (t) => t }),
       });
 
     const TOP = "top";
@@ -420,48 +419,46 @@ describe("Coroutine", () => {
     const DEPTH = 4;
 
     // Frontier of workflows to run; seed with the genuine top-level root
-    // (origin == prefix == its id).
-    let frontier: Array<{ id: string; oId: string; prId: string }> = [{ id: TOP, oId: TOP, prId: TOP }];
+    // (origin == its id).
+    let frontier: Array<{ id: string; oId: string }> = [{ id: TOP, oId: TOP }];
     const lengths = new Set<number>();
     const ids = new Set<string>();
 
     for (let level = 0; level < DEPTH; level++) {
-      const next: Array<{ id: string; oId: string; prId: string }> = [];
-      for (const { id, oId, prId } of frontier) {
-        const ctx = makeCtx(id, oId, prId);
+      const next: Array<{ id: string; oId: string }> = [];
+      for (const { id, oId } of frontier) {
+        const ctx = makeCtx(id, oId);
         for (let i = 0; i < FANOUT; i++) {
           const rfi = ctx.detached("fires");
           lengths.add(rfi.id.length);
           ids.add(rfi.id);
-          // Re-root as production does: oId = origin tag (its own id), prId =
-          // prefix tag (the top, propagated unchanged -- what bounds the id).
+          // Re-seed as production does: oId = origin tag (the parent's origin,
+          // propagated unchanged -- what bounds the id).
           next.push({
             id: rfi.id,
             oId: rfi.createReq.data.tags?.["resonate:origin"] as string,
-            prId: rfi.createReq.data.tags?.["resonate:prefix"] as string,
           });
         }
       }
       frontier = next;
     }
 
-    // Bounded: a single length across all depths, exactly `${top}.d${14hex}`.
+    // Bounded: a single length across all depths, exactly `${top}:d${14hex}`.
     expect(lengths.size).toBe(1);
-    expect([...lengths][0]).toBe(TOP.length + ".d".length + 14);
+    expect([...lengths][0]).toBe(TOP.length + ":d".length + 14);
     // ...and no collisions: every node in the tree got a distinct id.
-    expect(ids.size).toBe((FANOUT ** (DEPTH + 1) - FANOUT) / (FANOUT - 1));
+    expect(ids.size).toBe(FANOUT + FANOUT ** 2 + FANOUT ** 3 + FANOUT ** 4);
   });
 
-  test("detached breaks the origin lineage and starts a new one, even with an explicit id", () => {
-    // "detached" is fire-and-forget and runs as its own root, so resonate:origin
-    // is reset to its own id (origin == id == branch) -- a fresh lineage -- even
-    // with a caller-pinned id. The id-generation prefix (resonate:prefix) is
-    // carried forward unchanged, independent of the diverging origin.
-    const optsBuilder = new OptionsBuilder({ match: (t) => t, idPrefix: "" });
+  test("detached with an explicit id starts a fresh self-anchored lineage", () => {
+    // A caller-pinned id cannot extend the current lineage, so it starts a
+    // fresh one: the server requires an id to extend its declared origin /
+    // branch / parent, which only the id itself satisfies
+    // (origin == branch == parent == id, exactly like a top-level run).
+    const optsBuilder = new OptionsBuilder({ match: (t) => t });
     const ctx = new InnerContext({
       id: "wf",
       oId: "top",
-      prId: "top",
       func: "fires",
       clock: new WallClock(),
       registry: new Registry(),
@@ -475,9 +472,11 @@ describe("Coroutine", () => {
     const rfi = ctx.detached("fires", optsBuilder.build({ id: "custom-detached" }));
 
     expect(rfi.id).toBe("custom-detached");
-    // Origin is the detached's own id (new lineage); prefix is propagated.
     expect(rfi.createReq.data.tags?.["resonate:origin"]).toBe("custom-detached");
-    expect(rfi.createReq.data.tags?.["resonate:prefix"]).toBe("top");
+    expect(rfi.createReq.data.tags?.["resonate:parent"]).toBe("custom-detached");
+    expect(rfi.createReq.data.tags?.["resonate:branch"]).toBe("custom-detached");
+    // The resonate:prefix tag is gone.
+    expect(rfi.createReq.data.tags?.["resonate:prefix"]).toBeUndefined();
   });
 
   test("lfc/rfc", async () => {
@@ -494,14 +493,14 @@ describe("Coroutine", () => {
     const network = new DummyNetwork();
     const effects = buildEffects(network);
 
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
     expect(r.type).toBe("suspended");
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1);
 
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo:1.1", { kind: "value", value: 42 });
 
-    r = await exec("foo.1", foo, [], effects);
+    r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 84 } });
   });
 
@@ -521,7 +520,7 @@ describe("Coroutine", () => {
       Coroutine.exec(
         testLogger,
         new InnerContext({
-          id: "foo.1",
+          id: "foo:1",
           func: foo.name,
           clock: new WallClock(),
           registry: new Registry(),
@@ -529,7 +528,7 @@ describe("Coroutine", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (t) => t, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (t) => t }),
         }),
         foo,
         [],
@@ -549,7 +548,7 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 
@@ -572,7 +571,7 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: "caught: boom" } });
   });
 
@@ -602,7 +601,7 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 3 } });
 
     // Both started before either completes (true concurrency)
@@ -626,16 +625,16 @@ describe("Coroutine", () => {
     const effects = buildEffects(network);
 
     // First execution: child suspends on remote → parent suspends too
-    let r = await exec("foo.1", parent, [], effects);
+    let r = await exec("foo:1", parent, [], effects);
     expect(r.type).toBe("suspended");
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1);
 
     // Settle the remote promise that the child was waiting on
-    await completePromise(effects, "foo.1.0.0", { kind: "value", value: 21 });
+    await completePromise(effects, "foo:1.0.0", { kind: "value", value: 21 });
 
     // Second execution: child completes → parent completes
-    r = await exec("foo.1", parent, [], effects);
+    r = await exec("foo:1", parent, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 43 } });
   });
 
@@ -654,14 +653,14 @@ describe("Coroutine", () => {
     const effects = buildEffects(network);
 
     // First execution: local flushed + settled inline, remote still pending
-    let r = await exec("foo.1", foo, [], effects);
+    let r = await exec("foo:1", foo, [], effects);
     expect(r.type).toBe("suspended");
 
     // Settle remote
-    await completePromise(effects, "foo.1.1", { kind: "value", value: 42 });
+    await completePromise(effects, "foo:1.1", { kind: "value", value: 42 });
 
     // Re-execution: local promise already settled (fast-forward), completes
-    r = await exec("foo.1", foo, [], effects);
+    r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 77 } });
   });
 
@@ -691,18 +690,18 @@ describe("Coroutine", () => {
 
     // First execution: parent suspends on remoteParent.
     // The child's local work must be flushed, surfacing its remote dep.
-    let r = await exec("p.1", parent, [], effects);
+    let r = await exec("p:1", parent, [], effects);
     expect(r.type).toBe("suspended");
     const suspended = r as Suspended;
     // Must include BOTH remoteParent AND the child's remoteChild
     expect(suspended.todo.remote.length).toBeGreaterThanOrEqual(2);
 
     // Settle both remote promises
-    await completePromise(effects, "p.1.0", { kind: "value", value: 5 });
-    await completePromise(effects, "p.1.1.0", { kind: "value", value: 3 });
+    await completePromise(effects, "p:1.0", { kind: "value", value: 5 });
+    await completePromise(effects, "p:1.1.0", { kind: "value", value: 3 });
 
     // Second execution: everything settled → done
-    r = await exec("p.1", parent, [], effects);
+    r = await exec("p:1", parent, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 35 } });
   });
 
@@ -724,16 +723,16 @@ describe("Coroutine", () => {
     const effects = buildEffects(network);
 
     // First execution: suspends on remote, but local bar() must be flushed and settled
-    let r = await exec("p.1", parent, [], effects);
+    let r = await exec("p:1", parent, [], effects);
     expect(r.type).toBe("suspended");
     const suspended = r as Suspended;
     expect(suspended.todo.remote).toHaveLength(1); // only remoteParent
 
     // Settle the remote
-    await completePromise(effects, "p.1.0", { kind: "value", value: 8 });
+    await completePromise(effects, "p:1.0", { kind: "value", value: 8 });
 
     // Second execution: bar's durable promise was settled on first run → replay fast-path
-    r = await exec("p.1", parent, [], effects);
+    r = await exec("p:1", parent, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 50 } });
   });
 
@@ -752,7 +751,7 @@ describe("Coroutine", () => {
 
     const network = new DummyNetwork();
     const effects = buildEffects(network);
-    const r = await exec("foo.1", foo, [], effects);
+    const r = await exec("foo:1", foo, [], effects);
     expect(r).toMatchObject({ type: "done", result: { kind: "value", value: 42 } });
   });
 });

--- a/tests/decorator.test.ts
+++ b/tests/decorator.test.ts
@@ -42,7 +42,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -50,7 +50,7 @@ describe("Decorator", () => {
 
     expect(r).toMatchObject({
       type: "internal.async.l",
-      id: "foo.0",
+      id: "foo:0",
     });
   });
 
@@ -90,7 +90,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -165,7 +165,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -177,14 +177,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     }); // pending promise → generator gets Future(pending), advances to second LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -220,7 +220,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -231,7 +231,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -243,14 +243,14 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.1",
+      id: "foo:1",
     }); // B -> pending promise → generator gets Future(pending), advances to C -> LFI
     expect(r).toMatchObject({ type: "internal.async.l" });
 
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -287,7 +287,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -298,7 +298,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.0",
+      id: "foo:0",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 10 },
@@ -309,7 +309,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.1",
+      id: "foo:1",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 20 },
@@ -320,7 +320,7 @@ describe("Decorator", () => {
     r = d.next({
       type: "internal.promise",
       state: "completed",
-      id: "foo.2",
+      id: "foo:2",
       value: {
         type: "internal.literal",
         value: { kind: "value", value: 30 },
@@ -356,7 +356,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -390,7 +390,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -427,7 +427,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -493,7 +493,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -507,10 +507,10 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     // Generator advances to yield* f (Future iterator: yield this)
-    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo.0" } });
+    expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending", id: "foo:0" } });
 
     // Coroutine resolves inline and feeds a literal back
     r = d.next({
@@ -551,7 +551,7 @@ describe("Decorator", () => {
           timeout: 0,
           version: 1,
           retryPolicy: new Never(),
-          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}`, idPrefix: "" }),
+          optsBuilder: new OptionsBuilder({ match: (target: string) => `local://any@${target}` }),
         }),
       ),
     );
@@ -565,7 +565,7 @@ describe("Decorator", () => {
       type: "internal.promise",
       state: "pending",
       mode: "attached",
-      id: "foo.0",
+      id: "foo:0",
     });
     expect(r).toMatchObject({ type: "internal.await", promise: { state: "pending" } });
 

--- a/tests/equivalence/workloads.ts
+++ b/tests/equivalence/workloads.ts
@@ -205,6 +205,6 @@ export const humanInTheLoop: MatchedWorkload = {
   gen: { dpc: dpcGen },
   async: { dpc: dpcAsync },
   drive: async (api) => {
-    await api.resolvePromise("dpc.0", "signal");
+    await api.resolvePromise("dpc:0", "signal");
   },
 };

--- a/tests/id-format.test.ts
+++ b/tests/id-format.test.ts
@@ -1,0 +1,327 @@
+/**
+ * Compliance tests for the promise id format the server enforces. Mirrors
+ * resonate-sdk-py/tests/test_id_format.py.
+ *
+ * The server (resonatehq/resonate, "new promise id" / PR #1127) treats a
+ * promise id as `<origin>:<lineage>`: the origin is everything before the
+ * first `:` and the lineage segments below it are `.`-separated:
+ *
+ *   root -> root:1 -> root:1.1 -> root:1.1.1
+ *
+ * `serverValidate` is a direct port of the server's
+ * `validate_promise_create_data`, and `serverOrigin` of its `origin()` helper.
+ * Every promise the SDK creates is replayed through them here, so a drift in
+ * id minting fails locally instead of as a 400 from a real server.
+ */
+
+import type { Context, Info } from "../src/async/context.js";
+import { Resonate } from "../src/async/resonate.js";
+import { joinId, originOf, validateRootId } from "../src/ids.js";
+import { LocalNetwork, Server } from "../src/network/local.js";
+import type { Network } from "../src/network/network.js";
+import * as util from "../src/util.js";
+
+// =============================================================================
+// The server's rules, ported
+// =============================================================================
+
+/** The origin, per the server's `origin()`: text before the first `:`. */
+function serverOrigin(id: string): string {
+  const sep = id.indexOf(":");
+  return sep === -1 ? id : id.slice(0, sep);
+}
+
+/** Port of the server's `validate_promise_create_data`. Throws on violation. */
+function serverValidate(id: string, tags: Record<string, string>): void {
+  if (id.includes("\0")) throw new Error(`null_bytes: id=${id}`);
+
+  const origin = tags["resonate:origin"];
+  if (origin !== undefined) {
+    if (origin.includes(".")) throw new Error(`dot_in_origin: origin=${origin}`);
+    if (origin.includes(":")) throw new Error(`colon_in_origin: origin=${origin}`);
+    if (id !== origin && !id.startsWith(`${origin}:`)) {
+      throw new Error(`origin_prefix: id=${id} is not prefixed by origin=${origin}`);
+    }
+  }
+  for (const key of ["resonate:branch", "resonate:parent"]) {
+    const ancestor = tags[key];
+    if (ancestor !== undefined) {
+      // A bare root joins its first lineage segment with ':'; an ancestor that
+      // already carries lineage joins deeper segments with '.'.
+      const sep = ancestor.includes(":") ? "." : ":";
+      if (id !== ancestor && !id.startsWith(`${ancestor}${sep}`)) {
+        throw new Error(`${key}_prefix: id=${id} is not prefixed by ${key}=${ancestor}`);
+      }
+    }
+  }
+  const prefix = tags["resonate:prefix"];
+  if (prefix?.includes(".")) {
+    throw new Error(`dot_in_prefix: prefix=${prefix}`);
+  }
+}
+
+// =============================================================================
+// Workflow under test
+// =============================================================================
+
+/** Records every promise.create request (direct or nested in task.create). */
+class RecordingNetwork implements Network {
+  readonly creates: string[] = [];
+  readonly tags = new Map<string, Record<string, string>>();
+  constructor(private inner: Network) {}
+  get unicast() {
+    return this.inner.unicast;
+  }
+  get anycast() {
+    return this.inner.anycast;
+  }
+  match(target: string) {
+    return this.inner.match(target);
+  }
+  init() {
+    return this.inner.init();
+  }
+  stop() {
+    return this.inner.stop();
+  }
+  send: Network["send"] = ((req: any) => {
+    const data =
+      req.kind === "promise.create"
+        ? req.data
+        : req.data?.action?.kind === "promise.create"
+          ? req.data.action.data
+          : undefined;
+    if (data) {
+      this.creates.push(data.id);
+      this.tags.set(data.id, data.tags);
+    }
+    return this.inner.send(req);
+  }) as Network["send"];
+  recv: Network["recv"] = (cb) => this.inner.recv(cb);
+}
+
+/**
+ * Run a nested workflow — runs below runs, a durable sleep, and detached
+ * children spawned from a nested context (one of which detaches again) — and
+ * return every (id, tags) pair the SDK created.
+ */
+async function runWorkflow(rootId: string): Promise<{ creates: string[]; tags: Map<string, Record<string, string>> }> {
+  const recording = new RecordingNetwork(new LocalNetwork({ pid: "default", group: "default" }));
+  const resonate = new Resonate({ network: recording, ttl: Number.MAX_SAFE_INTEGER });
+  try {
+    const leaf = async (_info: Info, n: number): Promise<number> => n;
+    const tail = async (_info: Info, n: number): Promise<number> => n;
+    const grandchild = async (ctx: Context, n: number): Promise<number> => {
+      await ctx.run("leaf", n);
+      return n;
+    };
+    // A detached child that itself detaches — the recursion-bounding case.
+    const detachesAgain = async (ctx: Context, n: number): Promise<number> => {
+      await ctx.detached("tail", n);
+      return n;
+    };
+    const mid = async (ctx: Context, n: number): Promise<number> => {
+      await ctx.run("grandchild", n);
+      // A global-scope timer promise: minted from the same seq as everything
+      // else. A 1ms sleep settles fast enough for the pass to continue.
+      await ctx.sleep(1);
+      // Detached from a *nested* context: its id is minted off the origin,
+      // not off this context, so its declared ancestors must be the origin
+      // too.
+      await ctx.detached("detachesAgain", n);
+      return n;
+    };
+    const top = async (ctx: Context, n: number): Promise<number> => {
+      await ctx.run("mid", n);
+      await ctx.run("mid", n + 1);
+      return n;
+    };
+    resonate.register("leaf", leaf);
+    resonate.register("tail", tail);
+    resonate.register("grandchild", grandchild);
+    resonate.register("detachesAgain", detachesAgain);
+    resonate.register("mid", mid);
+    resonate.register("top", top);
+
+    await (await resonate.run(rootId, top, 1)).result();
+
+    // Let the fire-and-forget detached children be dispatched and run: 2x mid
+    // each detach a child that detaches again -> 4 detached promises.
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const detached = recording.creates.filter((id) => id.startsWith(`${rootId}:d`));
+      if (detached.length >= 4) break;
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    return { creates: [...new Set(recording.creates)], tags: recording.tags };
+  } finally {
+    await resonate.stop();
+  }
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("promise id format compliance (async engine)", () => {
+  let created: { creates: string[]; tags: Map<string, Record<string, string>> };
+
+  beforeAll(async () => {
+    created = await runWorkflow("wf");
+  });
+
+  test("every created promise passes server validation", () => {
+    expect(created.creates.length).toBeGreaterThan(1);
+    for (const id of created.creates) {
+      serverValidate(id, created.tags.get(id) ?? {});
+    }
+  });
+
+  test("whole workflow shares one origin", () => {
+    // The origin is the server's partition key and the unit both
+    // promise.register_callback and task.suspend match on, so every promise a
+    // workflow creates — detached children included — must share it.
+    for (const id of created.creates) {
+      expect(serverOrigin(id)).toBe("wf");
+      expect(created.tags.get(id)?.["resonate:origin"]).toBe("wf");
+    }
+  });
+
+  test("child ids are colon-then-dot separated", () => {
+    // First level below the root joins with ':', deeper levels with '.'.
+    expect(created.creates).toContain("wf");
+    expect(created.creates).toContain("wf:0");
+    expect(created.creates).toContain("wf:0.0");
+    expect(created.creates).toContain("wf:0.0.0");
+    // No id keeps the old all-'.' shape.
+    expect(created.creates.filter((id) => id.startsWith("wf."))).toEqual([]);
+  });
+
+  test("detached ids stay bounded below the origin", () => {
+    // Detached ids are `{origin}:d{14 hex}` — one segment past the origin no
+    // matter how deep the spawning context is, or how many times a detached
+    // child detaches again.
+    const detached = created.creates.filter((id) => id.startsWith("wf:d"));
+    expect(detached.length).toBe(4); // 2x mid, each detaching a child that detaches
+    for (const id of detached) {
+      expect(id).toMatch(/^wf:d[0-9a-f]{14}$/);
+      // The id hangs off the origin, not off the spawning context, so the
+      // origin is also the ancestor it declares; branch stays the child's own.
+      expect(created.tags.get(id)?.["resonate:parent"]).toBe("wf");
+      expect(created.tags.get(id)?.["resonate:branch"]).toBe(id);
+    }
+  });
+
+  test("the resonate:prefix tag is not emitted", () => {
+    for (const id of created.creates) {
+      expect(created.tags.get(id)?.["resonate:prefix"]).toBeUndefined();
+    }
+  });
+});
+
+describe("ids module", () => {
+  test("joinId matches the server's separator rule", () => {
+    expect(joinId("root", "1")).toBe("root:1");
+    expect(joinId("root:1", "2")).toBe("root:1.2");
+    expect(joinId("root:1.2", "3")).toBe("root:1.2.3");
+    expect(joinId("root", "dbeef")).toBe("root:dbeef");
+  });
+
+  test("originOf matches the server's origin()", () => {
+    for (const id of ["root", "root:1", "root:1.2", "root:dbeef"]) {
+      expect(originOf(id)).toBe(serverOrigin(id));
+    }
+  });
+
+  test.each(["a.b", "a:b", "a.b:c", "", "a\0b"])("validateRootId rejects %j", (id) => {
+    // Both separators are reserved in a root id: it becomes the origin of its
+    // whole lineage, and the server rejects an origin containing either one
+    // outright (dot_in_origin / colon_in_origin).
+    expect(() => validateRootId(id)).toThrow(/Invalid id/);
+  });
+
+  test.each(["a", "a-b", "a_b", "wf-1786636678653183000"])("validateRootId accepts %j", (id) => {
+    expect(validateRootId(id)).toBe(id);
+  });
+
+  test("a dot in a root id is rejected by the server", () => {
+    // '.' cannot even create the root: the origin tag would hold one.
+    expect(() => serverValidate("a.b", { "resonate:origin": "a.b" })).toThrow(/dot_in_origin/);
+  });
+
+  test("a colon in a root id is rejected by the server", () => {
+    // ':' cannot create the root either: a root is its own origin, and the
+    // origin is everything before an id's first ':', so an origin holding one
+    // is unrepresentable — no id could ever split back to it.
+    expect(() => serverValidate("a:b", { "resonate:origin": "a:b" })).toThrow(/colon_in_origin/);
+  });
+
+  test("detachedId agrees with the id format", () => {
+    const id = util.detachedId("wf", "wf:3");
+    expect(id).toMatch(/^wf:d[0-9a-f]{14}$/);
+    expect(originOf(id)).toBe("wf");
+  });
+});
+
+// =============================================================================
+// Scheduler invariant: only targeted promises are timed out
+// =============================================================================
+//
+// Mirrors the server's promise.pendingHasTimeout invariant: a pending promise
+// carrying resonate:target always has a timeout scheduled, and one without a
+// target must NOT. Divergence here is invisible in ordinary tests — a
+// simulation that schedules timeouts for *every* promise simply lets more
+// things succeed than the real server does — so it is asserted directly
+// against the state machine.
+
+describe("local server scheduler invariant", () => {
+  function createPromise(server: Server, now: number, id: string, timeoutAt: number, tags: Record<string, string>) {
+    const { response } = server.apply(now, {
+      kind: "promise.create",
+      head: { corrId: id, version: util.VERSION },
+      data: { id, timeoutAt, param: { headers: {}, data: "" }, tags },
+    } as any);
+    expect((response as any).head.status).toBe(200);
+  }
+
+  test("only promises with a target are scheduled for timeout", () => {
+    const server = new Server({ timeoutMode: "none" });
+    const now = 1_000_000;
+    const deadline = now + 60_000;
+
+    createPromise(server, now, "no-target", deadline, { "resonate:scope": "global" });
+    createPromise(server, now, "with-target", deadline, {
+      "resonate:scope": "global",
+      "resonate:target": "poll://any@default",
+    });
+
+    const scheduled = server.pTimeouts.map((pt) => pt.id);
+    expect(scheduled).toContain("with-target");
+    expect(scheduled).not.toContain("no-target");
+  });
+
+  test("tick expires only the targeted promise", () => {
+    const server = new Server({ timeoutMode: "none" });
+    const now = 1_000_000;
+    const deadline = now + 60_000;
+
+    createPromise(server, now, "bare", deadline, { "resonate:scope": "global" });
+    createPromise(server, now, "timer", deadline, {
+      "resonate:scope": "global",
+      "resonate:target": "poll://any@default",
+      "resonate:timer": "true",
+    });
+
+    server.apply(deadline + 1, {
+      kind: "debug.tick",
+      head: { corrId: "tick", version: util.VERSION },
+      data: { time: deadline + 1 },
+    } as any);
+
+    // The timer fires — and resonate:timer settles it RESOLVED, which is what
+    // wakes a sleeping workflow. The bare promise is left alone.
+    expect(server.promises.get("timer")?.state).toBe("resolved");
+    expect(server.promises.get("bare")?.state).toBe("pending");
+  });
+});

--- a/tests/id-format.test.ts
+++ b/tests/id-format.test.ts
@@ -37,7 +37,6 @@ function serverValidate(id: string, tags: Record<string, string>): void {
 
   const origin = tags["resonate:origin"];
   if (origin !== undefined) {
-    if (origin.includes(".")) throw new Error(`dot_in_origin: origin=${origin}`);
     if (origin.includes(":")) throw new Error(`colon_in_origin: origin=${origin}`);
     if (id !== origin && !id.startsWith(`${origin}:`)) {
       throw new Error(`origin_prefix: id=${id} is not prefixed by origin=${origin}`);
@@ -171,10 +170,14 @@ describe("promise id format compliance (async engine)", () => {
     created = await runWorkflow("wf");
   });
 
-  test("every created promise passes server validation", () => {
-    expect(created.creates.length).toBeGreaterThan(1);
-    for (const id of created.creates) {
-      serverValidate(id, created.tags.get(id) ?? {});
+  test.each(["wf", "my.app.workflow"])("every created promise passes server validation (root %s)", async (root) => {
+    // A dotted root is a caller's prerogative: '.' is only read below the
+    // origin, so every id minted under it still validates.
+    const result = await runWorkflow(root);
+    expect(result.creates.length).toBeGreaterThan(1);
+    for (const id of result.creates) {
+      serverValidate(id, result.tags.get(id) ?? {});
+      expect(serverOrigin(id)).toBe(root);
     }
   });
 
@@ -234,20 +237,25 @@ describe("ids module", () => {
     }
   });
 
-  test.each(["a.b", "a:b", "a.b:c", "", "a\0b"])("validateRootId rejects %j", (id) => {
-    // Both separators are reserved in a root id: it becomes the origin of its
-    // whole lineage, and the server rejects an origin containing either one
-    // outright (dot_in_origin / colon_in_origin).
+  test.each(["a:b", "a.b:c", "", "a\0b"])("validateRootId rejects %j", (id) => {
+    // ':' is the one reserved separator in a root id: it becomes the origin of
+    // its whole lineage. See the test below for what it actually breaks.
     expect(() => validateRootId(id)).toThrow(/Invalid id/);
   });
 
-  test.each(["a", "a-b", "a_b", "wf-1786636678653183000"])("validateRootId accepts %j", (id) => {
+  test.each(["a", "a-b", "a_b", "a.b", "wf-1786636678653183000"])("validateRootId accepts %j", (id) => {
     expect(validateRootId(id)).toBe(id);
   });
 
-  test("a dot in a root id is rejected by the server", () => {
-    // '.' cannot even create the root: the origin tag would hold one.
-    expect(() => serverValidate("a.b", { "resonate:origin": "a.b" })).toThrow(/dot_in_origin/);
+  test("a dot in a root id is accepted", () => {
+    // '.' only separates lineage segments *below* the origin, which is read
+    // after the origin has been split off at the first ':'. A dotted root is
+    // therefore unambiguous, and the server takes it.
+    expect(validateRootId("my.app.workflow")).toBe("my.app.workflow");
+    const id = joinId("my.app.workflow", "1");
+    expect(id).toBe("my.app.workflow:1");
+    expect(originOf(id)).toBe("my.app.workflow");
+    serverValidate(id, { "resonate:origin": "my.app.workflow" });
   });
 
   test("a colon in a root id is rejected by the server", () => {

--- a/tests/network/nats.test.ts
+++ b/tests/network/nats.test.ts
@@ -195,8 +195,8 @@ describe("NatsNetwork.send()", () => {
     net = new NatsNetwork({ conn: fake as any, pid: "p1", group: "g1" });
     await net.init();
 
-    // origin is the lineage root: substring before the first dot of the id.
-    await net.send(promiseGetReq("foo.bar.baz", "c1"));
+    // origin is the lineage root: substring before the first colon of the id.
+    await net.send(promiseGetReq("foo:bar.baz", "c1"));
 
     const token = Buffer.from("foo", "utf8").toString("base64url");
     const reqPublish = fake.published.find((p) => p.subject.startsWith("resonate.requests."));
@@ -230,7 +230,7 @@ describe("NatsNetwork.send()", () => {
         action: {
           kind: "promise.create",
           head: { corrId: "c1", version: VERSION },
-          data: { id: "root.child.1", timeoutAt: 1, param: {}, tags: {} },
+          data: { id: "root:child.1", timeoutAt: 1, param: {}, tags: {} },
         },
       },
     };

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -83,46 +83,43 @@ describe("Resonate usage tests", () => {
     });
 
     function* bar(ctx: Context): Generator {
-      // origin: foo.1
-      // parent: foo.1
-      // branch: foo.1.0
+      // origin: foo1
+      // parent: foo1
+      // branch: foo1:0
       const v = yield ctx.rpc(baz);
       return v;
     }
 
     async function baz(ctx: Context): Promise<string> {
-      // origin: foo.1
-      // parent: foo.1.0
-      // branch: foo.1.0.0
+      // origin: foo1
+      // parent: foo1:0
+      // branch: foo1:0.0
       return "hello";
     }
 
     resonate.register(bar);
     resonate.register(baz);
 
-    const v = await f.run("foo.1");
+    const v = await f.run("foo1");
     expect(await v).toBe("hello");
-    expect((await resonate.promises.get("foo.1")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1:0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1:0",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1.0.0",
-      "resonate:parent": "foo.1.0",
+    expect((await resonate.promises.get("foo1:0.0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1:0.0",
+      "resonate:parent": "foo1:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -150,25 +147,22 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
-      "resonate:branch": "foo.0",
+      "resonate:branch": "foo:0",
       "resonate:parent": "foo",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
-      "resonate:branch": "foo.0.0",
-      "resonate:parent": "foo.0",
+      "resonate:branch": "foo:0.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "global",
       "resonate:target": "local://any@default",
     });
@@ -190,28 +184,25 @@ describe("Resonate usage tests", () => {
       return "hello";
     }
 
-    const v = await f.run("foo.1");
+    const v = await f.run("foo1");
     expect(await v).toBe("hello");
-    expect((await resonate.promises.get("foo.1")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.1.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1",
+    expect((await resonate.promises.get("foo1:0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.1.0.0")).tags).toEqual({
-      "resonate:origin": "foo.1",
-      "resonate:prefix": "foo.1",
-      "resonate:branch": "foo.1",
-      "resonate:parent": "foo.1.0",
+    expect((await resonate.promises.get("foo1:0.0")).tags).toEqual({
+      "resonate:origin": "foo1",
+      "resonate:branch": "foo1",
+      "resonate:parent": "foo1:0",
       "resonate:scope": "local",
     });
   });
@@ -235,24 +226,21 @@ describe("Resonate usage tests", () => {
     expect(await v).toBe("hello");
     expect((await resonate.promises.get("foo")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "global",
       "resonate:target": "local://any@default/default",
     });
-    expect((await resonate.promises.get("foo.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
       "resonate:parent": "foo",
       "resonate:scope": "local",
     });
-    expect((await resonate.promises.get("foo.0.0")).tags).toEqual({
+    expect((await resonate.promises.get("foo:0.0")).tags).toEqual({
       "resonate:origin": "foo",
-      "resonate:prefix": "foo",
       "resonate:branch": "foo",
-      "resonate:parent": "foo.0",
+      "resonate:parent": "foo:0",
       "resonate:scope": "local",
     });
   });
@@ -454,14 +442,14 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function", ctx.options({ tags: { myTag: "value" } }));
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toMatchObject({ myTag: "value", "resonate:scope": "local" });
     await resonate.stop();
   });
@@ -479,7 +467,7 @@ describe("Resonate usage tests", () => {
     for (const [i, target] of ["default", "foo", "bar", "baz"].entries()) {
       await resonate.rpc(`f${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`f${i}`);
-      const p2 = await resonate.promises.get(`f${i}.0`);
+      const p2 = await resonate.promises.get(`f${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(`local://any@${target}`);
       expect(p2.tags["resonate:target"]).toBe(`local://any@${target}`);
@@ -497,7 +485,7 @@ describe("Resonate usage tests", () => {
     ].entries()) {
       await resonate.rpc(`g${i}`, "foo", target, resonate.options({ target }));
       const p1 = await resonate.promises.get(`g${i}`);
-      const p2 = await resonate.promises.get(`g${i}.0`);
+      const p2 = await resonate.promises.get(`g${i}:0`);
 
       expect(p1.tags["resonate:target"]).toBe(target);
       expect(p2.tags["resonate:target"]).toBe(target);
@@ -514,20 +502,19 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.beginRun(g, "this is a function");
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const v = await f.run("f");
     expect(v.msg).toBe("this is a function");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "local",
       "resonate:branch": "f",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
     });
     await resonate.stop();
   });
@@ -538,21 +525,20 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure f.0 promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -563,21 +549,20 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise();
-      expect(fu.id).toBe(`${ctx.id}.0`);
+      expect(fu.id).toBe(`${ctx.id}:0`);
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure myId promise is created
 
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
-    expect((await resonate.promises.get("f.0")).tags).toEqual({
-      "resonate:branch": "f.0",
+    expect((await resonate.promises.get("f:0")).tags).toEqual({
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
@@ -591,24 +576,23 @@ describe("Resonate usage tests", () => {
 
     const f = resonate.register("f", function* foo(ctx: Context) {
       const fu = yield* ctx.promise({ timeout: 5 * util.HOUR });
-      expect(fu.id).toBe("f.0");
+      expect(fu.id).toBe("f:0");
       return yield* fu;
     });
 
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure f.0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.timeoutAt).toBeGreaterThanOrEqual(time + 5 * util.HOUR);
     expect(durable.timeoutAt).toBeLessThan(time + 5 * util.HOUR + 1000);
     expect(durable.tags).toEqual({
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
     });
-    await resonate.promises.resolve("f.0", { data: encodeValue(codec, "myValue").data });
+    await resonate.promises.resolve("f:0", { data: encodeValue(codec, "myValue").data });
     const v = await p.result();
     expect(v).toBe("myValue");
     await resonate.stop();
@@ -626,14 +610,16 @@ describe("Resonate usage tests", () => {
     const p = await f.beginRun("f");
     await setTimeout(100); // Ensure f.0 promise is created
 
-    const durable = await resonate.promises.get("f.0");
+    const durable = await resonate.promises.get("f:0");
     expect(durable.tags).toEqual({
       "resonate:timer": "true",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:parent": "f",
       "resonate:scope": "global",
+      // The server only schedules a timeout for a promise carrying a target,
+      // so a target-less timer would never fire — the timer must carry one.
+      "resonate:target": "local://any@default",
     });
     expect(durable.timeoutAt).toBeLessThan(time + 1 * util.SEC + 100);
 
@@ -657,7 +643,7 @@ describe("Resonate usage tests", () => {
     const v = await f.run("f");
     expect(v).toBe("myValue");
 
-    const durable = await resonate.promises.get(util.detachedId("f", "f.0"));
+    const durable = await resonate.promises.get(util.detachedId("f", "f:0"));
     expect(durable).toMatchObject({ state: "pending" });
 
     await resonate.stop();
@@ -764,14 +750,13 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "local://any@default",
     });
     await resonate.stop();
@@ -790,14 +775,13 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "local://any@remoteTarget",
     });
     await resonate.stop();
@@ -816,14 +800,13 @@ describe("Resonate usage tests", () => {
     });
 
     await f.run("f");
-    const durable = await resonate.promises.get("f.0");
-    expect(durable.id).toBe("f.0");
+    const durable = await resonate.promises.get("f:0");
+    expect(durable.id).toBe("f:0");
     expect(durable.tags).toStrictEqual({
       "resonate:scope": "global",
-      "resonate:branch": "f.0",
+      "resonate:branch": "f:0",
       "resonate:parent": "f",
       "resonate:origin": "f",
-      "resonate:prefix": "f",
       "resonate:target": "http://faasurl.com",
     });
     await resonate.stop();
@@ -849,7 +832,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "http://faasurl.com",
     });
     await resonate.stop();
@@ -875,7 +857,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "local://any@default",
     });
     await resonate.stop();
@@ -901,7 +882,6 @@ describe("Resonate usage tests", () => {
       "resonate:branch": "fid",
       "resonate:parent": "fid",
       "resonate:origin": "fid",
-      "resonate:prefix": "fid",
       "resonate:target": "local://any@anotherNode",
     });
     await resonate.stop();
@@ -1056,38 +1036,26 @@ describe("Resonate usage tests", () => {
     await resonate.stop();
   });
 
-  test("Using prefix at Resonate class prefixes all the promises", async () => {
-    const prefix = "myPrefix";
-    const resonate = new Resonate({ prefix });
-
-    function qux(ctx: Context) {
-      expect(ctx.id.startsWith(prefix));
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "qux";
-    }
-
-    function* baz(ctx: Context) {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      yield* ctx.run(qux);
-      return "baz";
-    }
-
-    function* bar(ctx: Context) {
-      expect(ctx.id.startsWith(prefix)).toBe(true);
-      expect(ctx.id.startsWith(`${prefix}:${prefix}`)).toBe(false);
-      return "bar";
-    }
-
-    function* foo(ctx: Context) {
-      const p = yield* ctx.beginRun(bar);
-      yield* ctx.run(baz);
-      yield* ctx.run(qux);
-      yield* p;
+  test("run/rpc/schedule reject an invalid root id; get does not validate", async () => {
+    // Raised at the call site, before anything reaches the server: a root id
+    // becomes the origin of its whole lineage, so the reserved separators
+    // ('.' and ':') are rejected outright.
+    const resonate = new Resonate();
+    function noop(_ctx: Context) {
       return "ok";
     }
-    const f = resonate.register("foo", foo);
-    await f.run("fooId");
+    resonate.register("vnoop", noop);
+
+    for (const bad of ["bad.id", "bad:id", "", "bad\u0000id"]) {
+      await expect(resonate.beginRun(bad, "vnoop")).rejects.toThrow(/Invalid id/);
+      await expect(resonate.beginRpc(bad, "vnoop")).rejects.toThrow(/Invalid id/);
+      await expect(resonate.schedule(bad, "* * * * *", "vnoop")).rejects.toThrow(/Invalid id/);
+    }
+
+    // get is a lookup, not a create: it takes any id, including a child's
+    // (e.g. "wf:1.2"), so it must NOT validate. A missing one 404s rather
+    // than raising InvalidId.
+    await expect(resonate.get("wf:1.2")).rejects.toThrow(/not found|404|exist/i);
 
     await resonate.stop();
   });
@@ -1254,10 +1222,10 @@ describe("Context usage tests", () => {
       expect(ctxRetryPolicy).toEqual(retryPolicy);
 
       if (f === "rfi" || f === "rfc") {
-        const p = await resonate.promises.get(`f${i}.0`);
+        const p = await resonate.promises.get(`f${i}:0`);
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       } else if (f === "detached") {
-        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}.0`));
+        const p = await resonate.promises.get(util.detachedId(`f${i}`, `f${i}:0`));
         expect(JSON.parse(util.base64Decode(p.param.data!)).retry).toEqual(retryPolicy.encode());
       }
     }

--- a/tests/resonate.test.ts
+++ b/tests/resonate.test.ts
@@ -1038,15 +1038,15 @@ describe("Resonate usage tests", () => {
 
   test("run/rpc/schedule reject an invalid root id; get does not validate", async () => {
     // Raised at the call site, before anything reaches the server: a root id
-    // becomes the origin of its whole lineage, so the reserved separators
-    // ('.' and ':') are rejected outright.
+    // becomes the origin of its whole lineage, so ':' is rejected outright
+    // ('.' is only read below the origin).
     const resonate = new Resonate();
     function noop(_ctx: Context) {
       return "ok";
     }
     resonate.register("vnoop", noop);
 
-    for (const bad of ["bad.id", "bad:id", "", "bad\u0000id"]) {
+    for (const bad of ["bad:id", "", "bad\u0000id"]) {
       await expect(resonate.beginRun(bad, "vnoop")).rejects.toThrow(/Invalid id/);
       await expect(resonate.beginRpc(bad, "vnoop")).rejects.toThrow(/Invalid id/);
       await expect(resonate.schedule(bad, "* * * * *", "vnoop")).rejects.toThrow(/Invalid id/);

--- a/tests/timer-task.test.ts
+++ b/tests/timer-task.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Timer tasks (durable sleep). Mirrors resonate-sdk-py/tests/test_core.py's
+ * timer-task group, for both engines.
+ *
+ * A `resonate:timer` promise is a durable sleep: the wake IS its deadline, and
+ * `resonate:timer` makes timing out settle it *resolved*. It carries a
+ * `resonate:target` only because the server refuses to schedule a deadline for
+ * a promise without one — which also spawns a task, dispatched right away
+ * rather than at the wake. That task names no function, so Core must neither
+ * run it nor hand it back (a release is re-dispatched immediately, which would
+ * spin): it drops it and lets the deadline do the waking.
+ */
+
+import { Core as AsyncCore } from "../src/async/core.js";
+import { WallClock } from "../src/clock.js";
+import { Codec } from "../src/codec.js";
+import { Core } from "../src/core.js";
+import { NoopHeartbeat } from "../src/heartbeat.js";
+import { ConsoleLogger } from "../src/logger.js";
+import { LocalNetwork } from "../src/network/local.js";
+import type { PromiseRecord, Request, TaskRecord } from "../src/network/types.js";
+import { OptionsBuilder } from "../src/options.js";
+import { randomUUID } from "../src/platform.js";
+import { Registry } from "../src/registry.js";
+import type { Send } from "../src/types.js";
+import * as util from "../src/util.js";
+
+const FAR_FUTURE = 2 ** 50;
+
+function buildHarness() {
+  const network = new LocalNetwork();
+  const codec = new Codec();
+  const logger = new ConsoleLogger("error");
+  const sent: Request[] = [];
+  const send: Send = ((req: any) => {
+    sent.push(req);
+    return network.send(req);
+  }) as Send;
+  const common = {
+    pid: "test-pid",
+    ttl: 60_000,
+    clock: new WallClock(),
+    send,
+    codec,
+    registry: new Registry(),
+    heartbeat: new NoopHeartbeat(),
+    dependencies: new Map<string, any>(),
+    optsBuilder: new OptionsBuilder({ match: (t: string) => t }),
+    logger,
+  };
+  return { network, codec, sent, send, common };
+}
+
+/** Create a timer promise the way ctx.sleep does, then acquire its task. */
+async function acquireTimerTask(
+  send: Send,
+  id: string,
+  timeoutAt: number,
+): Promise<{ task: TaskRecord; promise: PromiseRecord }> {
+  const createRes: any = await send({
+    kind: "promise.create",
+    head: { corrId: randomUUID(), version: util.VERSION },
+    data: {
+      id,
+      timeoutAt,
+      param: { headers: {}, data: "" },
+      tags: {
+        "resonate:scope": "global",
+        "resonate:branch": id,
+        "resonate:target": "local://any@default",
+        "resonate:timer": "true",
+      },
+    },
+  } as any);
+  expect(createRes.head.status).toBe(200);
+
+  const acquireRes: any = await send({
+    kind: "task.acquire",
+    head: { corrId: randomUUID(), version: util.VERSION },
+    data: { id, version: 0, pid: "test-pid", ttl: 60_000 },
+  } as any);
+  expect(acquireRes.head.status).toBe(200);
+  return { task: acquireRes.data.task, promise: acquireRes.data.promise };
+}
+
+describe.each([
+  ["generator engine", (common: any) => new Core(common)],
+  ["async engine", (common: any) => new AsyncCore(common)],
+])("timer tasks — %s", (_name, makeCore) => {
+  test("a not-yet-due timer task is dropped", async () => {
+    const { sent, send, common } = buildHarness();
+    const core = makeCore(common);
+    const { task, promise } = await acquireTimerTask(send, "t-pending", FAR_FUTURE);
+    expect(promise.state).toBe("pending");
+
+    sent.length = 0;
+    const status = await core.executeUntilBlocked(task, promise);
+
+    expect(status.kind).toBe("suspended");
+    // Dropped means dropped: no fulfill (that would end the sleep early), no
+    // suspend, no release — nothing reached the server at all.
+    expect(sent).toEqual([]);
+    // Still pending: the sleep was not ended early.
+    const getRes: any = await send({
+      kind: "promise.get",
+      head: { corrId: randomUUID(), version: util.VERSION },
+      data: { id: "t-pending" },
+    } as any);
+    expect(getRes.data.promise.state).toBe("pending");
+  });
+
+  test("a due timer fulfills the task without decoding", async () => {
+    // A delivery already in flight when the deadline settled the promise. A
+    // timer's empty param holds no TaskData, so this has to short-circuit
+    // before the decode rather than fail on it.
+    const { sent, send, common } = buildHarness();
+    const core = makeCore(common);
+    const { task, promise } = await acquireTimerTask(send, "t-due", FAR_FUTURE);
+
+    // The record as the worker would observe it after the deadline settled it.
+    const settled: PromiseRecord = { ...promise, state: "resolved", value: { headers: {}, data: undefined } };
+
+    sent.length = 0;
+    const status = await core.executeUntilBlocked(task, settled);
+
+    expect(status.kind).toBe("done");
+    expect((status as any).state).toBe("resolved");
+    const fulfill = sent.find((r) => r.kind === "task.fulfill");
+    expect(fulfill).toBeDefined();
+    expect((fulfill as any).data.action.data.state).toBe("resolved");
+  });
+});

--- a/tests/trace.test.ts
+++ b/tests/trace.test.ts
@@ -37,7 +37,7 @@ class TestHeartbeat implements Heartbeat {
 
 async function buildComputation(
   registry: Registry,
-  id = "foo.1",
+  id = "foo:1",
 ): Promise<{
   computation: Computation;
   network: Network;
@@ -84,7 +84,7 @@ async function buildComputation(
     registry,
     new TestHeartbeat(),
     new Map(),
-    new OptionsBuilder({ match: (target: string) => target, idPrefix: "test-" }),
+    new OptionsBuilder({ match: (target: string) => target }),
     logger,
   );
 
@@ -167,7 +167,7 @@ describe("Trace", () => {
       registry.add(add, "add");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "main", []);
+      const rootPromise = createRootPromise("foo:1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("done");
@@ -176,22 +176,22 @@ describe("Trace", () => {
       const trace = res.trace;
 
       // Root spawn is first
-      expect(trace[0]).toEqual({ kind: "spawn", id: "foo.1" });
+      expect(trace[0]).toEqual({ kind: "spawn", id: "foo:1" });
 
       // Should have run event from parent to child
       const runEvt = trace.find((e) => e.kind === "run");
       expect(runEvt).toBeDefined();
       expect(runEvt!.kind).toBe("run");
       if (runEvt!.kind === "run") {
-        expect(runEvt!.id).toBe("foo.1");
+        expect(runEvt!.id).toBe("foo:1");
       }
 
       // Should have spawn for child
-      const childSpawns = trace.filter((e) => e.kind === "spawn" && e.id !== "foo.1");
+      const childSpawns = trace.filter((e) => e.kind === "spawn" && e.id !== "foo:1");
       expect(childSpawns.length).toBe(1);
 
       // Should have return for child
-      const childReturns = trace.filter((e) => e.kind === "return" && e.id !== "foo.1");
+      const childReturns = trace.filter((e) => e.kind === "return" && e.id !== "foo:1");
       expect(childReturns.length).toBe(1);
       if (childReturns[0].kind === "return") {
         expect(childReturns[0].state).toBe("resolved");
@@ -207,7 +207,7 @@ describe("Trace", () => {
       // Root return is last
       const lastEvt = trace[trace.length - 1];
       expect(lastEvt.kind).toBe("return");
-      expect(lastEvt.id).toBe("foo.1");
+      expect(lastEvt.id).toBe("foo:1");
       if (lastEvt.kind === "return") {
         expect(lastEvt.state).toBe("resolved");
         expect(lastEvt.value).toBe(7);
@@ -227,18 +227,18 @@ describe("Trace", () => {
       registry.add(main, "main");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "main", []);
+      const rootPromise = createRootPromise("foo:1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("suspended");
       const trace = res.trace;
 
-      expect(trace[0]).toEqual({ kind: "spawn", id: "foo.1" });
+      expect(trace[0]).toEqual({ kind: "spawn", id: "foo:1" });
 
       // rpc event
       const rpcEvt = trace.find((e) => e.kind === "rpc");
       expect(rpcEvt).toBeDefined();
-      expect(rpcEvt!.id).toBe("foo.1");
+      expect(rpcEvt!.id).toBe("foo:1");
 
       // block event for the callee
       const blockEvt = trace.find((e) => e.kind === "block");
@@ -251,7 +251,7 @@ describe("Trace", () => {
       // suspend event (terminal)
       const suspendEvt = trace.find((e) => e.kind === "suspend");
       expect(suspendEvt).toBeDefined();
-      expect(suspendEvt!.id).toBe("foo.1");
+      expect(suspendEvt!.id).toBe("foo:1");
 
       expect(isWellFormed(trace)).toBe(true);
     });
@@ -269,7 +269,7 @@ describe("Trace", () => {
       registry.add(main, "main");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "main", []);
+      const rootPromise = createRootPromise("foo:1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("suspended");
@@ -309,7 +309,7 @@ describe("Trace", () => {
       registry.add(compute, "compute");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "main", []);
+      const rootPromise = createRootPromise("foo:1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("suspended");
@@ -324,10 +324,10 @@ describe("Trace", () => {
       expect(rpcEvt).toBeDefined();
 
       // local child should spawn + return
-      const childSpawns = trace.filter((e) => e.kind === "spawn" && e.id !== "foo.1");
+      const childSpawns = trace.filter((e) => e.kind === "spawn" && e.id !== "foo:1");
       expect(childSpawns.length).toBe(1);
 
-      const childReturns = trace.filter((e) => e.kind === "return" && e.id !== "foo.1");
+      const childReturns = trace.filter((e) => e.kind === "return" && e.id !== "foo:1");
       expect(childReturns.length).toBe(1);
 
       // block for remote child
@@ -337,7 +337,7 @@ describe("Trace", () => {
       // parent suspends
       const suspendEvt = trace.find((e) => e.kind === "suspend");
       expect(suspendEvt).toBeDefined();
-      expect(suspendEvt!.id).toBe("foo.1");
+      expect(suspendEvt!.id).toBe("foo:1");
 
       expect(isWellFormed(trace)).toBe(true);
     });
@@ -353,7 +353,7 @@ describe("Trace", () => {
       registry.add(factorial, "factorial");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "factorial", [3]);
+      const rootPromise = createRootPromise("foo:1", "factorial", [3]);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("done");
@@ -387,15 +387,15 @@ describe("Trace", () => {
       registry.add(add, "add");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "add", [3, 4]);
+      const rootPromise = createRootPromise("foo:1", "add", [3, 4]);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("done");
       const trace = res.trace;
 
       expect(trace.length).toBe(2);
-      expect(trace[0]).toEqual({ kind: "spawn", id: "foo.1" });
-      expect(trace[1]).toEqual({ kind: "return", id: "foo.1", state: "resolved", value: 7 });
+      expect(trace[0]).toEqual({ kind: "spawn", id: "foo:1" });
+      expect(trace[1]).toEqual({ kind: "return", id: "foo:1", state: "resolved", value: 7 });
       expect(isWellFormed(trace)).toBe(true);
     });
 
@@ -409,7 +409,7 @@ describe("Trace", () => {
 
       const { computation } = await buildComputation(registry);
       const rootPromise: PromiseRecord = {
-        id: "foo.1",
+        id: "foo:1",
         state: "resolved",
         param: { headers: {}, data: { func: "main", args: [], version: 1 } as any },
         tags: { "resonate:target": "default" },
@@ -426,7 +426,7 @@ describe("Trace", () => {
       expect(trace.length).toBe(1);
       expect(trace[0].kind).toBe("dedup");
       if (trace[0].kind === "dedup") {
-        expect(trace[0].id).toBe("foo.1");
+        expect(trace[0].id).toBe("foo:1");
         expect(trace[0].state).toBe("resolved");
       }
       // A dedup-only root trace doesn't start with spawn — that's correct per spec.
@@ -452,9 +452,9 @@ describe("Trace", () => {
       const { computation, effects } = await buildComputation(registry);
 
       // Pre-settle the child promise
-      await presettle(effects, "foo.1.0", 42);
+      await presettle(effects, "foo:1.0", 42);
 
-      const rootPromise = createRootPromise("foo.1", "main", []);
+      const rootPromise = createRootPromise("foo:1", "main", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("done");
@@ -490,7 +490,7 @@ describe("Trace", () => {
       registry.add(taskB, "taskB");
 
       const { computation } = await buildComputation(registry);
-      const rootPromise = createRootPromise("foo.1", "scatter", []);
+      const rootPromise = createRootPromise("foo:1", "scatter", []);
       const res = await computation.executeUntilBlocked(rootPromise);
 
       expect(res.kind).toBe("done");

--- a/tests/util.test.ts
+++ b/tests/util.test.ts
@@ -13,7 +13,7 @@ function makeCtx({
   timeout = Number.MAX_SAFE_INTEGER,
 } = {}) {
   const registry = new Registry();
-  const optsBuilder = new OptionsBuilder({ match: (t) => t, idPrefix: "" });
+  const optsBuilder = new OptionsBuilder({ match: (t) => t });
   return new InnerContext({
     id: "test",
     func: "testFunc",
@@ -180,40 +180,40 @@ describe("base64 encoder", () => {
 });
 
 describe("detachedId", () => {
-  test("returns prefix dot-d plus cyrb53 hex of seqid", () => {
-    const result = detachedId("root", "root.0");
-    expect(result).toBe(detachedId("root", "root.0"));
-    expect(result.startsWith("root.d")).toBe(true);
+  test("returns origin colon-d plus cyrb53 hex of seqid", () => {
+    const result = detachedId("root", "root:0");
+    expect(result).toBe(detachedId("root", "root:0"));
+    expect(result.startsWith("root:d")).toBe(true);
   });
 
-  test("segment after the prefix is a `d` marker followed by hex", () => {
-    const result = detachedId("origin", "origin.3");
-    const segment = result.split(".").slice(1).join(".");
+  test("segment after the origin is a `d` marker followed by hex", () => {
+    const result = detachedId("origin", "origin:3");
+    const segment = result.split(":").slice(1).join(":");
     expect(segment[0]).toBe("d");
     expect(segment.slice(1)).toMatch(/^[0-9a-f]+$/);
   });
 
   test("is deterministic — same inputs produce same output", () => {
-    expect(detachedId("a", "a.0")).toBe(detachedId("a", "a.0"));
+    expect(detachedId("a", "a:0")).toBe(detachedId("a", "a:0"));
   });
 
   test("different seqids produce different ids", () => {
-    expect(detachedId("root", "root.0")).not.toBe(detachedId("root", "root.1"));
+    expect(detachedId("root", "root:0")).not.toBe(detachedId("root", "root:1"));
   });
 
-  test("different prefixes produce different ids", () => {
-    expect(detachedId("root.0", "root.0.0")).not.toBe(detachedId("root.1", "root.0.0"));
+  test("different origins produce different ids", () => {
+    expect(detachedId("root0", "root:0.0")).not.toBe(detachedId("root1", "root:0.0"));
   });
 
-  test("prefix is preserved before the `.d` segment", () => {
-    const prefix = "my-workflow-abc123";
-    const result = detachedId(prefix, "my-workflow-abc123.5");
-    expect(result.startsWith(`${prefix}.d`)).toBe(true);
+  test("origin is preserved before the `:d` segment", () => {
+    const origin = "my-workflow-abc123";
+    const result = detachedId(origin, "my-workflow-abc123:5");
+    expect(result.startsWith(`${origin}:d`)).toBe(true);
   });
 
   test("works with empty strings", () => {
     const result = detachedId("", "");
-    expect(result.startsWith(".d")).toBe(true);
+    expect(result.startsWith(":d")).toBe(true);
   });
 });
 


### PR DESCRIPTION
Ports the promise id format change to the TypeScript SDK — **both engines** (generator `src/` and async `src/async/`) plus the `aws` / `gcp` / `cloudflare` packages and the simulator — mirroring resonate-sdk-py `ec67529` (see also the server's `new promise id` rules, resonatehq/resonate#1127, and its `colon_in_origin` guard, commit `d6fae28`).

Every promise id is now `<origin>:<lineage>`: the **origin** (before the first `:`) is the caller-supplied workflow id, and the lineage segments below it are `.`-separated:

```
root -> root:0 -> root:0.0 -> root:0.0.0
```

`:` and `.` are therefore **reserved** and rejected in caller-supplied root ids.

### 1. `RESONATE_PREFIX` support removed (breaking)

- The `prefix` constructor option and `RESONATE_PREFIX` env var are gone from the core SDK (both engines) and from `@resonatehq/aws`, `@resonatehq/gcp`, and `@resonatehq/cloudflare`.
- Ids are no longer rewritten to `{prefix}:{id}` — the id you pass to `run` / `rpc` / `get` / `schedule` is the id you get.
- The `resonate:prefix` tag is no longer emitted on any promise.

### 2. Id minting follows the server's separator rule

New module **`src/ids.ts`**: `joinId` (a bare root joins its first lineage segment with `:`, deeper ones with `.`), `originOf` (everything before the first `:`, mirroring the server's `origin()`), and `validateRootId`.

- `src/context.ts`, `src/async/context.ts` — child ids minted with `joinId`; the `prefixId` plumbing is gone (the origin doubles as the id-generation anchor). `ctx.detached` mints `{origin}:d{14hex}` and **keeps the parent's origin** (the server requires every id in a lineage to extend its origin), declaring the origin as its `resonate:parent`; recursion stays bounded at one segment past the origin.
- An **explicit-id child** (`options({ id })` on run/rpc/detached) now starts a fresh *self-anchored* lineage — `origin == branch == parent == id`, exactly like a top-level run — since the server requires an id to extend its declared ancestors, which only the id itself satisfies. The id is validated like a root id.
- `src/computation.ts`, `src/async/core.ts` — the root context's origin comes from the `resonate:origin` tag, falling back to `originOf(id)` for tag-less promises (same derivation the server uses).
- `src/resonate.ts`, `src/async/resonate.ts` — top-level promise tags are now `origin == branch == parent == id`.
- `src/network/nats.ts` — request routing derives the origin-state partition by splitting on `:` (previously `.`), agreeing with the server's `origin()` for every id shape.

### 3. `:` (and `.`) rejected in user-supplied ids

- `run` / `beginRun`, `rpc` / `beginRpc`, and `schedule` validate the id at the call site and throw an **`InvalidId` `ResonateError`** (code 10, new) instead of surfacing an opaque 400 from a background create. `get` is a lookup and deliberately does not validate (it accepts child ids like `wf:0.1`).
- `schedule` templates the fired promise id as `{{.id}}-{{.timestamp}}` (previously `.`-joined): the server stamps the whole templated id as the fired promise's origin, so it must stay a single bare segment.

### 4. Durable sleep vs target-gated timeouts

Since server commit `c8d7c7b` the scheduler only times out promises carrying a `resonate:target`; a target-less `ctx.sleep` promise would never fire.

- Both contexts — timer promises now carry a `resonate:target`; `resonate:timer` makes the deadline settle the promise **resolved**, which wakes the sleepers.
- Both Cores — the target also spawns a task dispatched immediately; a timer names no function, so Core drops a task for a still-pending timer (no fulfill, no suspend, no release) and short-circuits a settled timer's task before decoding.
- `src/network/local.ts` — the local server now mirrors the invariant (only targeted promises are scheduled for timeout), so this class of bug fails locally instead of only against a real server.

### Examples

- `structured-concurrency`, `human-in-the-loop` (both engines) — child-id comments/lookups updated to `{id}:0` shape.

### Tests

- **`tests/id-format.test.ts`** (new) — a direct port of the server's `validate_promise_create_data` / `origin()`; every promise the SDK creates is replayed through it, plus `joinId` / `originOf` / `validateRootId`, detached id shape, call-site rejection, and the local-server scheduler invariant.
- **`tests/timer-task.test.ts`** (new) — timer-task drop / short-circuit for both engines.
- Prefix tests removed; child-id expectations updated to `root:0` shape throughout.

### Verification

- `npm test` — **460 passed**
- `tsc` (root + all three packages), `biome check`, `npm run build` — clean
- DST simulator: failures at seeds 1/42 verified identical on the unmodified baseline (pre-existing, unrelated)
